### PR TITLE
Add batch prediction, customer details tool, conversation memory

### DIFF
--- a/PROJECT_ROADMAP.md
+++ b/PROJECT_ROADMAP.md
@@ -323,178 +323,123 @@ Presentation Day                   ███████████████
 
 ---
 
-## Phase 0 — Setup & Scaffolding (Mar 31 – Apr 1)
+## Phase 0 — Setup & Scaffolding (Mar 31 – Apr 1) ✅ COMPLETE
 
-**Goal:** Repo structure, Kanban board, API contracts agreed, one vertical slice working locally.
-
-### Troy — Git & CI/CD Setup
-- [ ] Set up GitHub Projects Kanban board with columns: `Backlog`, `In Progress`, `In Review`, `Done`
-- [ ] Create tasks from this roadmap as GitHub Issues and assign owners
-- [ ] Set branch protection on `main` (require PR + 1 approval)
-- [ ] Agree on branch naming convention with team (e.g., `feat/<owner>-<description>`, `fix/...`)
-- [ ] Scaffold `.github/workflows/` with placeholder workflow files
-- [ ] Create `docker-compose.yaml` skeleton for local dev
-
-### George — Infrastructure & Backend Scaffold
-- [ ] Scaffold `terraform/` directory (main.tf, variables.tf, outputs.tf, providers.tf)
-- [ ] Identify which AWS resources are pre-existing (shared VPC, EKS cluster, IAM roles) vs. need provisioning
-- [ ] Scaffold `k8s/` with namespace + configmap templates
-- [ ] Scaffold `backend/` with FastAPI hello world (`/health`, `/ready`, `/chat` stubs)
-- [ ] Write first Dockerfile for backend
-- [ ] Verify Bedrock model access in `us-east-1`
-
-### Okino — ML Endpoint 1 (Transcript/QA Evaluator)
-- [ ] Download sentiment dataset from Kaggle ("Customer Support on Twitter" or "Amazon Reviews")
-- [ ] Scaffold `sagemaker/transcript/` with train.py notebook + data/ directory
-- [ ] Scaffold `ml-wrappers/transcript/` with FastAPI stub (app.py, Dockerfile, requirements.txt)
-- [ ] Begin data exploration and preprocessing
-
-### Kathleen — ML Endpoint 2 (Churn Predictor)
-- [ ] Download "Telco Customer Churn" (IBM) dataset from Kaggle
-- [ ] Scaffold `sagemaker/churn/` with train.py notebook + data/ directory
-- [ ] Scaffold `ml-wrappers/churn/` with FastAPI stub (app.py, Dockerfile, requirements.txt)
-- [ ] Begin data exploration and preprocessing
-
-### All — Day 1 Sync
-- [ ] Agree on API contracts (see Interface Contracts section above)
-- [ ] Each member documents their LLM setup in `docs/llm-usage/`
-- [ ] Decide frontend framework: React (more polished, bonus points) or Streamlit (faster to build)
-
-### Milestone ✓
-> Every team member can run `docker-compose up` and hit the backend `/health` endpoint.
+### Troy — [x] Kanban board, branch protection, workflow stubs, docker-compose
+### George — [x] Terraform, K8s manifests, agent service scaffold, Dockerfiles, Bedrock access
+### Okino — [x] TriLink transcript dataset, sentiment-analysis-api scaffold, training notebook
+### Kathleen — [x] TriLink churn dataset, sagemaker/churn scaffold, churn-predictor-api scaffold
+### All — [x] API contracts agreed, React + Vite + Tailwind chosen, LLM usage logging started
 
 ---
 
-## Phase 1 — Core Services (Apr 2 – Apr 8)
-
-**Goal:** ML endpoints live, agent wired with tools, CI green. The core pipeline works locally.
+## Phase 1 — Core Services (Apr 2 – Apr 8) ✅ MOSTLY COMPLETE
 
 ### Troy — CI/CD Pipelines
-- [ ] CI workflow: build + push backend image to GHCR
-- [ ] CI workflow: build + push ML wrapper images to GHCR
-- [ ] CI workflow: build + push frontend image to GHCR
-- [ ] Add verification step (health check) to each workflow
-- [ ] Use `docker/build-push-action` + GitHub Secrets for registry credentials
+- [ ] CI workflow: build + push images to GHCR (placeholder files exist, need implementation)
 
-### Okino — QA/Transcript Evaluator (Train + Deploy)
-- [ ] **Train Endpoint 1 in SageMaker:**
-  - Preprocess sentiment dataset (tokenize, label encode)
-  - Train DistilBERT/RoBERTa text classifier
-  - Deploy to SageMaker endpoint
-  - Verify: `aws sagemaker describe-endpoint --endpoint-name transcript-endpoint-v1`
-- [ ] **FastAPI wrapper (`ml-wrappers/transcript/`):**
-  - `POST /predict` — accepts `{"text": "..."}`, returns `{"category": "...", "sentiment": "...", "confidence": 0.91}`
-  - `GET /health` — returns `{"status": "healthy", "endpoint": "transcript-endpoint-v1"}`
-  - Invoke SageMaker endpoint from FastAPI using `boto3`
-- [ ] Write Dockerfile (multi-stage build, slim base, `.dockerignore`, health check)
-- [ ] Test: `curl localhost:8000/predict -d '{"text": "I am very upset"}'`
+### Okino — QA/Transcript Evaluator
+- [x] Training notebook (`services/sentiment-analysis-api/sentiment_training.ipynb`)
+- [x] FastAPI wrapper with Bedrock-powered sentiment analysis
+- [x] Dockerfile, K8s deployment + service manifests
+- [x] Terraform `sagemaker.tf` for endpoint config
+- [ ] SageMaker endpoint deployment — in progress
+- [ ] `/predict` route must return: qa_score, sentiment, emotion_frustration, emotion_anger, sentiment_shift, escalation_flag, resolution_flag
 
-### Kathleen — Churn Predictor (Train + Deploy)
-- [ ] **Train Endpoint 2 in SageMaker:**
-  - Preprocess Telco Churn dataset (encode categoricals, scale numerics)
-  - Train XGBoost/LightGBM model
-  - Deploy to SageMaker endpoint
-  - Verify: `aws sagemaker describe-endpoint --endpoint-name churn-endpoint-v1`
-- [ ] **FastAPI wrapper (`ml-wrappers/churn/`):**
-  - `POST /predict` — accepts `{"features": [0.5, 1.0, 3, 45.2, ...]}`, returns `{"churn_probability": 0.82, "prediction": "churn"}`
-  - `GET /health` — returns `{"status": "healthy", "endpoint": "churn-endpoint-v1"}`
-  - Invoke SageMaker endpoint from FastAPI using `boto3`
-- [ ] Write Dockerfile (multi-stage build, slim base, `.dockerignore`, health check)
-- [ ] Test: `curl localhost:8000/predict -d '{"features": [...]}'`
+### Kathleen — Churn Predictor ✅
+- [x] XGBoost model v3: 95% accuracy, 0.9861 AUC, 31 features
+- [x] Cross-model integration: 7 Agent 1 features from synthetic call data
+- [x] SageMaker endpoint deployed (XGBoost container, native format) — InService
+- [x] FastAPI wrapper with internal customer data lookup from S3
+- [x] `/predict` accepts customer_id + Agent 1 fields, looks up account data internally
+- [x] `/customers` API for frontend searchable dropdown
+- [x] `/customer-details/{id}` API for agent tool
+- [x] `/high-risk` API with batch SageMaker prediction + caching
+- [x] Dockerfile (multi-stage build, slim base, health check)
 
-### George — LangChain Agent + Backend
-- [ ] **Terraform apply** — provision core cloud resources:
-  - S3 bucket (data storage)
-  - IAM roles for SageMaker execution and Bedrock access
-  - Reference existing VPC/EKS (use `data` sources or `terraform import`)
-- [ ] Document lifecycle: `terraform init` → `plan` → `apply` in `docs/setup.md`
-- [ ] Set up remote state with S3 + DynamoDB locking (bonus)
-- [ ] **Write LangChain agent** with tool definitions:
-  - `churn_tool` → calls churn-wrapper `/predict`
-  - `transcript_tool` → calls transcript-wrapper `/predict`
-  - `bedrock_tool` → Bedrock invoke for general chat
-- [ ] Wire agent into backend `/chat` route
-- [ ] Write K8s deployments + services for all containers
+### Kathleen & Okino — Orchestration ✅
+- [x] retention_agent.py: 4-tool agent (get_customer_details, analyze_call, predict_churn, get_high_risk_customers)
+- [x] TriLink product catalog with approved retention actions per risk level
+- [x] Output guardrails validating agent recommendations
+- [x] Conversation memory (InMemoryChatMessageHistory, session-based)
+- [x] Intelligent routing: agent decides tools based on question type
+- [x] churn_tool.py: sends customer_id + 7 Agent 1 fields
+- [x] high_risk_tool.py: fetches ranked at-risk customer list
+- [x] customer_tool.py: looks up account details for conversational queries
 
-### Milestone ✓
-> From local, you can POST to `/chat` with "Will this customer churn?" and the agent calls the churn endpoint and returns a response.
+### George — Infrastructure & Agent
+- [x] Terraform: S3, IAM roles, sagemaker.tf, iam.tf, s3.tf
+- [x] K8s: all deployments, services, configmaps, secrets, namespace quota
+- [x] Agent service: app.py with /chat route, CORS, session_id support
+- [x] docker-compose.yml for full local stack
+- [ ] Deploy full stack to EKS
+
+### Kathleen — Frontend ✅
+- [x] React + Vite + Tailwind Manager's Command Center
+- [x] **Analyze tab**: searchable customer dropdown, RiskCard, SentimentCard, ActionCard
+- [x] **Chat tab**: conversational Bedrock interface with smart fallback
+- [x] Lucide React SVG icons (professional)
+- [x] Dockerfile (multi-stage: node → nginx)
 
 ---
 
 ## Phase 2 — Infrastructure, Deploy & CI/CD (Apr 9 – Apr 15)
 
-**Goal:** Everything running on Kubernetes, CI/CD deploys automatically, full agentic pipeline working.
-
 ### Troy — Deploy Pipeline
+- [ ] Write actual CI/CD workflows (currently empty placeholders)
 - [ ] Deploy workflow: `kubectl apply -f k8s/` triggered on merge to main
-- [ ] Add rollback step to deploy workflow (bonus)
-- [ ] Set up branch-based targeting: staging vs prod (bonus)
-- [ ] Add verification steps:
-  - Health check after deployment
-  - `kubectl rollout status deployment/<name>`
-  - Smoke test: curl `/health` endpoints
+- [ ] Add verification steps (health check, rollout status)
 
-### Kathleen & Okino — ML Hardening
-- [ ] Create the Customer ID mapping logic between datasets
-- [ ] Test cross-model pipeline: transcript → QA score → combine with account data → churn probability
-- [ ] Harden ML wrappers (bonus):
-  - Retry logic on SageMaker invocations
-  - Error handling and fallback responses
-  - Model versioning
-- [ ] Test endpoints under load, verify CloudWatch logs
+### Okino — Finish Endpoint 1
+- [ ] Deploy sentiment model to SageMaker endpoint
+- [ ] Confirm `/predict` output matches churn_tool.py expected fields
+- [ ] Test end-to-end: transcript → Agent 1 → Agent 2 → Agent 3
 
-### George — K8s Deploy & Agentic Pipeline
-- [ ] Deploy full stack to Minikube/EKS: `kubectl apply -f k8s/`
-- [ ] Add ConfigMaps + Secrets for env vars (endpoint URLs, AWS creds)
-- [ ] Add health probes to all deployments (liveness + readiness)
-- [ ] Verify Bedrock access from inside cluster
-- [ ] **Full multi-step agentic workflow:**
-  - Agent receives transcript → calls transcript tool → gets sentiment/QA score → calls churn tool with score + account data → if churn risk > 0.7, asks Bedrock to generate retention offer
-  - This satisfies: "non-trivial agentic behavior" + "multi-step reasoning" + "tool use"
-- [ ] Add Terraform resources for SageMaker endpoint configs, additional IAM policies
-- [ ] Modularize Terraform (bonus): `modules/networking`, `modules/compute`, `modules/sagemaker`
-- [ ] Add resource management (bonus): `ResourceQuota` + `LimitRange` per namespace
-- [ ] LangGraph workflow (bonus): model pipeline as state graph with conditional edges
-- [ ] LangSmith integration (bonus): `LANGCHAIN_TRACING_V2=true`
+### George — K8s Deploy
+- [ ] Deploy full stack to EKS
+- [ ] Verify Bedrock + SageMaker access from inside cluster
+- [ ] Test full agent pipeline from deployed frontend
 
-### Milestone ✓
-> Push to `main` triggers build → push → deploy. All pods healthy in cluster. Chat works via LoadBalancer URL.
+### Kathleen & Okino — Integration Testing
+- [ ] Test full 3-agent pipeline end-to-end with live endpoints
+- [ ] Verify high-risk batch prediction works on EKS
 
 ---
 
 ## Phase 3 — Frontend, Polish & Docs (Apr 16 – Apr 22)
 
-**Goal:** Chat UI live, full pipeline working, docs complete, demo-ready.
+### Frontend — Manager's Command Center
+- [x] Analyze tab with customer dropdown + results panel
+- [x] Chat tab with Bedrock conversational interface
+- [x] Lucide icons, Tailwind styling
+- [ ] "High Risk" leaderboard dashboard panel (bonus)
 
-### Frontend — Manager's Command Center (All)
-- [ ] Chat interface for interacting with the agent
-- [ ] Display: QA Score, Sentiment, Churn Probability, Retention Recommendation
-- [ ] "High Risk" leaderboard or dashboard panel
-- [ ] Conversation memory / context persistence (bonus)
-- [ ] Polish with Tailwind/MUI (bonus)
+### Memory Enhancement (Bonus — if time allows)
+- [ ] Integrate mem0 for persistent semantic memory (reference: CyberRisk portfolio project)
+- [ ] Requires: PostgreSQL + pgvector (could use AWS RDS)
+- [ ] Would enable: long-term user preferences, cross-session context, semantic search over past analyses
+- [ ] Alternative: current InMemoryChatMessageHistory is sufficient for demo
 
 ### Troy — Final CI/CD & Collaboration
 - [ ] Wire frontend CI/CD
-- [ ] Ensure all workflows pass on main
-- [ ] Final Kanban cleanup: all cards resolved
+- [ ] Final Kanban cleanup
 - [ ] Write docs: CI/CD setup guide, teardown steps
 
 ### Kathleen & Okino — ML Docs & Bonus
-- [ ] Verify both SageMaker endpoints are stable and responding
+- [x] Kathleen's SageMaker endpoint verified InService
+- [x] Kathleen LLM usage documented (`docs/llm-usage/kathleen-llm-usage.md`)
+- [ ] Okino's SageMaker endpoint — needs deployment
+- [ ] Okino LLM usage doc
 - [ ] Ensure model invocations work from inside K8s pods
-- [ ] Add 3rd endpoint or model versioning (bonus)
-- [ ] Write docs: ML approach, data decisions, LLM usage log
 
 ### George — Infrastructure Finalization
-- [ ] Verify all Terraform state is clean and reproducible
-- [ ] Test full lifecycle: `destroy` → `init` → `plan` → `apply`
-- [ ] Ensure no hardcoded credentials anywhere
-- [ ] Add HPA (Horizontal Pod Autoscaler) for high-traffic services (bonus)
-- [ ] Test: `kubectl exec <pod> -- curl localhost:8000/health` for each service
-- [ ] Write docs: architecture diagram, infra setup, deployment steps, teardown
+- [ ] Verify Terraform state is clean and reproducible
+- [ ] Terraform remote state with S3/DynamoDB (bonus)
+- [ ] Architecture diagram
+- [ ] Write docs: setup, deployment, teardown steps
 
 ### Bonus Integrations (Anyone)
-- [ ] Amazon Transcribe pipeline: S3 audio upload → Transcribe → feed transcript to agent
+- [ ] Amazon Transcribe pipeline: S3 audio → Transcribe → feed to agent
 - [ ] Amazon Polly: text-to-speech for agent responses
 
 ### Documentation (All Members)
@@ -563,30 +508,30 @@ Week 2 Focus:       Frontend     Frontend             Frontend
 
 ## Bonus Points Checklist
 
-| Area | Bonus Item | Difficulty | Owner |
-|------|-----------|------------|-------|
-| Containers | Alpine/slim bases, health checks, `.dockerignore` | Low | All |
-| Terraform | Remote state with S3/DynamoDB | Low | George |
-| Terraform | Modular structure (separate modules) | Medium | George |
-| CI/CD | Separate CI workflows per service | Low | Troy (already in plan) |
-| CI/CD | Branch targeting, rollback, multi-workflow chaining | Medium | Troy |
-| LangChain | LangGraph workflows | Medium | George |
-| LangChain | LangSmith observability | Medium | George |
-| Bedrock/Chat | Conversation memory persistence | Medium | George + frontend dev |
-| Bedrock/Chat | Polished UI (Tailwind/MUI) | Medium | Frontend dev |
-| SageMaker | Third endpoint or model versioning | Medium | Kathleen/Okino |
-| SageMaker | Retry logic, error handling, fallback | Medium | Kathleen/Okino |
-| K8s | ResourceQuota + LimitRange | Low | George |
-| K8s | HPA, persistent storage, rolling updates | Medium | George |
-| Collaboration | Sprint artifacts, retro notes, standup docs | Low | Troy + All |
-| Collaboration | Code review comments on PRs | Low | All |
-| Presentation | C4/sequence diagrams | Medium | All |
-| Presentation | Present early | Low | All |
-| LLM Usage | Compare LLM vs hand-written code | Medium | All |
-| LLM Usage | Document prompt engineering techniques | Low | All |
-| Extra | AWS Transcribe/Polly integration | Medium | Anyone |
-| Extra | Blog articles, MkDocs, video series | High | Anyone |
-| Extra | Portfolio page integration | High | Anyone |
+| Area | Bonus Item | Difficulty | Owner | Status |
+|------|-----------|------------|-------|--------|
+| Containers | Alpine/slim bases, health checks, `.dockerignore` | Low | All | ✅ Done |
+| Terraform | Remote state with S3/DynamoDB | Low | George | Pending |
+| Terraform | Modular structure (separate modules) | Medium | George | Pending |
+| CI/CD | Separate CI workflows per service | Low | Troy | Placeholder files exist |
+| CI/CD | Branch targeting, rollback, multi-workflow chaining | Medium | Troy | Pending |
+| LangChain | LangGraph workflows | Medium | George | Pending |
+| LangChain | LangSmith observability | Medium | George | Pending |
+| Bedrock/Chat | Conversation memory persistence | Medium | Kathleen | ✅ InMemory done, mem0 stretch |
+| Bedrock/Chat | Polished UI (Tailwind/MUI) | Medium | Kathleen | ✅ Tailwind + Lucide |
+| SageMaker | Third endpoint or model versioning | Medium | Kathleen/Okino | Pending |
+| SageMaker | Retry logic, error handling, fallback | Medium | Kathleen | ✅ Fallback in chat |
+| K8s | ResourceQuota + LimitRange | Low | George | ✅ Done |
+| K8s | HPA, persistent storage, rolling updates | Medium | George | Pending |
+| Collaboration | Sprint artifacts, retro notes, standup docs | Low | Troy + All | Pending |
+| Collaboration | Code review comments on PRs | Low | All | ✅ Done (40+ PRs) |
+| Presentation | C4/sequence diagrams | Medium | All | Pending |
+| Presentation | Present early | Low | All | Pending |
+| LLM Usage | Compare LLM vs hand-written code | Medium | Kathleen | ✅ In llm-usage doc |
+| LLM Usage | Document prompt engineering techniques | Low | Kathleen | ✅ In llm-usage doc |
+| Extra | AWS Transcribe/Polly integration | Medium | Anyone | Pending |
+| Extra | Blog articles, MkDocs, video series | High | Anyone | Pending |
+| Extra | Portfolio page integration | High | Anyone | Pending |
 
 ---
 

--- a/services/agent-service/app.py
+++ b/services/agent-service/app.py
@@ -54,6 +54,7 @@ app.add_middleware(
 class ChatRequest(BaseModel):
     message: str
     customer_id: str | None = None
+    session_id: str = "default"
 
 
 class ChatResponse(BaseModel):
@@ -82,7 +83,10 @@ async def chat(body: ChatRequest) -> ChatResponse:
         if body.customer_id:
             agent_input = f"Customer ID: {body.customer_id}\n\n{body.message}"
 
-        result = agent.invoke({"input": agent_input})
+        result = agent.invoke(
+            {"input": agent_input},
+            config={"configurable": {"session_id": body.session_id}},
+        )
         output = result.get("output", "")
 
         # Parse structured output

--- a/services/agent-service/chains/retention_agent.py
+++ b/services/agent-service/chains/retention_agent.py
@@ -1,12 +1,16 @@
 # services/agent-service/chains/retention_agent.py
 # The main LangChain agent that orchestrates the full retention analysis
-# Updated by Kathleen & Okino — 3-agent pipeline orchestration
+# Updated by Kathleen & Okino — 4-tool agent with memory
 
 from langchain_aws import ChatBedrock
 from langchain.agents import create_tool_calling_agent, AgentExecutor
-from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+from langchain_core.chat_history import InMemoryChatMessageHistory
+from langchain_core.runnables.history import RunnableWithMessageHistory
 from tools.qa_tool import analyze_call
 from tools.churn_tool import predict_churn
+from tools.high_risk_tool import get_high_risk_customers
+from tools.customer_tool import get_customer_details
 from dotenv import load_dotenv
 import os
 
@@ -16,24 +20,32 @@ MODEL_ID: str = os.getenv(key="MODEL_ID", default="us.anthropic.claude-haiku-4-5
 AWS_REGION: str = os.getenv(key="AWS_REGION", default="us-east-1")
 
 SYSTEM_PROMPT = """You are the Retention Engine AI for TriLink Telecom's customer support team.
-Your job is to analyze customer support calls and identify at-risk customers.
+You help retention managers analyze customer risk and take action to prevent churn.
 
-You have two tools:
-1. analyze_call — analyzes a transcript for sentiment, QA score, and emotional signals
-2. predict_churn — predicts churn probability using the QA analysis + account data
+You have four tools:
+1. get_customer_details — look up a customer's account info, plan, complaints, and call data
+2. analyze_call — analyze a transcript for sentiment, QA score, and emotional signals
+3. predict_churn — predict churn probability for a customer (uses account data + call signals)
+4. get_high_risk_customers — get a ranked list of the highest-risk customers
 
-WORKFLOW — follow these steps in order:
+ROUTING — choose the right approach based on the user's request:
 
-Step 1: When given a call transcript and customer_id, use analyze_call first.
-  This returns: qa_score, sentiment, emotion_frustration, emotion_anger,
-  sentiment_shift, escalation_flag, resolution_flag, category, confidence.
+If asked about a specific customer (e.g., "tell me about C00036458"):
+  1. Use get_customer_details to look up their account
+  2. Use predict_churn to get their risk score
+  3. Based on the risk level, recommend an approved action
 
-Step 2: Take ALL of those fields and pass them to predict_churn along with
-  the customer_id. The churn tool looks up account data internally.
-  This returns: churn_probability, prediction, risk_level.
+If asked to analyze a transcript:
+  1. Use analyze_call to get sentiment and QA score
+  2. Use predict_churn with the results + customer_id
+  3. Recommend an approved action based on risk level
 
-Step 3: Based on the combined results, select a recommendation from the
-  APPROVED ACTIONS below. Do NOT invent offers or plans that are not listed.
+If asked about high-risk customers, who to call, or a leaderboard:
+  → Use get_high_risk_customers to fetch the ranked list
+  → Present as a prioritized list with customer ID, risk %, plan, and sentiment
+
+If asked a general question about a customer you already discussed:
+  → Use your conversation memory — don't re-query unless asked to refresh
 
 TRILINK PRODUCT CATALOG:
   Internet Plans:
@@ -66,61 +78,64 @@ APPROVED RETENTION ACTIONS (choose one or combine based on risk level):
 
   LOW RISK (churn_probability < 0.40):
     - MONITOR: No retention action needed
-    - Note any positive agent performance for review
     Flag: None
 
-IMPORTANT: Only recommend actions from the lists above. Reference the
-customer's specific issues from the transcript when explaining why you
-chose each action.
-
-Always end your response in this exact format:
----
-Customer ID: [customer_id]
-QA Score: [X]/10
-Sentiment: [Positive/Neutral/Negative]
-Emotion - Frustration: [0-1] | Anger: [0-1]
-Sentiment Shift: [value]
-Escalated: [Yes/No] | Resolved: [Yes/No]
-Churn Risk: [LOW/MEDIUM/HIGH] ([probability as percentage]%)
-Action: [ACTION_CODE from approved list]
-Recommendation: [1-2 sentence explanation referencing the transcript]
----
+IMPORTANT: Only recommend actions from the lists above. Be conversational
+but precise. When presenting data, use clear formatting.
 """
 
+# Session-based chat history store
+_session_histories: dict[str, InMemoryChatMessageHistory] = {}
 
-def create_retention_agent() -> AgentExecutor:
-    """Creates and returns the configured LangChain agent executor."""
+
+def get_session_history(session_id: str) -> InMemoryChatMessageHistory:
+    if session_id not in _session_histories:
+        _session_histories[session_id] = InMemoryChatMessageHistory()
+    return _session_histories[session_id]
+
+
+def create_retention_agent() -> RunnableWithMessageHistory:
+    """Creates the agent with conversation memory."""
     llm = ChatBedrock(
         model=MODEL_ID,
         region=AWS_REGION,
         model_kwargs={"max_tokens": 1024, "temperature": 0},
     )
 
-    tools = [analyze_call, predict_churn]
+    tools = [get_customer_details, analyze_call, predict_churn, get_high_risk_customers]
 
     prompt = ChatPromptTemplate.from_messages(messages=[
         ("system", SYSTEM_PROMPT),
+        MessagesPlaceholder(variable_name="chat_history"),
         ("human", "{input}"),
         ("placeholder", "{agent_scratchpad}"),
     ])
 
     agent = create_tool_calling_agent(llm, tools, prompt)
 
-    return AgentExecutor(
+    executor = AgentExecutor(
         agent=agent,
         tools=tools,
         verbose=True,
-        max_iterations=5,
+        max_iterations=6,
         handle_parsing_errors=True,
     )
 
+    # Wrap with message history for conversation memory
+    return RunnableWithMessageHistory(
+        executor,
+        get_session_history,
+        input_messages_key="input",
+        history_messages_key="chat_history",
+    )
 
-# Singleton pattern — create once, reuse across requests
-_agent_executor: AgentExecutor | None = None
 
-def get_agent() -> AgentExecutor:
-    """Returns the shared agent instance, creating it on first call."""
-    global _agent_executor
-    if _agent_executor is None:
-        _agent_executor = create_retention_agent()
-    return _agent_executor
+# Singleton
+_agent: RunnableWithMessageHistory | None = None
+
+
+def get_agent() -> RunnableWithMessageHistory:
+    global _agent
+    if _agent is None:
+        _agent = create_retention_agent()
+    return _agent

--- a/services/agent-service/tools/customer_tool.py
+++ b/services/agent-service/tools/customer_tool.py
@@ -1,0 +1,36 @@
+# services/agent-service/tools/customer_tool.py
+# LangChain Tool that fetches customer account details
+
+import httpx
+import os
+from langchain.tools import tool
+
+CHURN_URL = os.getenv(key="CHURN_PREDICTOR_URL", default="http://localhost:8001")
+
+
+@tool
+def get_customer_details(customer_id: str) -> str:
+    """
+    Looks up account details for a customer including their plan, tenure,
+    complaints, and call sentiment data if available.
+    Use this when asked about a specific customer's account or history.
+
+    Args:
+        customer_id: The customer ID (e.g., C00036458)
+
+    Returns:
+        JSON with account details, plan info, complaints, and call data
+    """
+    try:
+        response = httpx.get(
+            url=f"{CHURN_URL}/customer-details/{customer_id}",
+            timeout=10.0,
+        )
+        response.raise_for_status()
+        return str(object=response.json())
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 404:
+            return f'{{"error": "Customer {customer_id} not found"}}'
+        return f'{{"error": "Service returned {e.response.status_code}"}}'
+    except Exception as e:
+        return f'{{"error": "{str(e)}"}}'

--- a/services/churn-predictor-api/app.py
+++ b/services/churn-predictor-api/app.py
@@ -2,19 +2,32 @@
 Churn Predictor API — FastAPI wrapper that looks up account data
 by customer_id, combines with Agent 1 output, and calls SageMaker.
 
-Routes: /predict and /health
+Routes: /predict, /customers, /high-risk, /customer-details, /health
 """
 
 import io
 import json
 import os
+import logging
 
 import boto3
+import numpy as np
 import pandas as pd
 from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
 app = FastAPI(title="Churn Predictor API")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 # --- Config ---
 REGION = os.environ.get("AWS_REGION", "us-east-1")
@@ -24,42 +37,209 @@ S3_BUCKET = os.environ.get("S3_BUCKET", "retention-engine-bucket")
 sagemaker_runtime = boto3.client("sagemaker-runtime", region_name=REGION)
 s3 = boto3.client("s3", region_name=REGION)
 
-# --- Load account data at startup ---
-# Cache the joined customer + internet data in memory so we don't hit S3 every request
+# --- Label encoders (must match training) ---
+LABEL_ENCODERS = {
+    "plan_tier": {"Basic_25": 0, "Premium_Gig": 1, "Standard_100": 2},
+    "contract_type": {"12_Month": 0, "24_Month": 1, "Month_to_Month": 2},
+    "income_bracket": {"High": 0, "Low": 1, "Middle": 2, "Upper_Middle": 3},
+    "home_ownership": {"Other": 0, "Own": 1, "Rent": 2},
+    "work_from_home_flag": {"False": 0, "True": 1},
+    "education_level": {"College": 0, "Graduate": 1, "HS": 2, "Professional": 3},
+    "life_stage": {"Empty_Nest": 0, "Established_Family": 1, "Senior": 2, "Single": 3, "Young_Family": 4},
+    "home_type": {"Apartment": 0, "Condo": 1, "Single_Family": 2, "Townhouse": 3},
+    "fiber_availability": {"False": 0, "True": 1},
+    "sentiment": {"Negative": 0, "Neutral": 1, "Positive": 2},
+}
+
+FEATURE_COLUMNS = [
+    "plan_tier", "speed_mbps", "monthly_cost", "data_usage_gb", "connected_devices",
+    "contract_type", "speed_complaints", "outage_count", "internet_tenure_days",
+    "contract_completed_percent", "age", "household_income", "income_bracket",
+    "family_size", "home_ownership", "work_from_home_flag", "education_level",
+    "life_stage", "home_type", "home_square_footage", "property_value",
+    "neighborhood_crime_rate", "neighborhood_income_median", "fiber_availability",
+    "qa_score", "sentiment", "emotion_frustration", "emotion_anger",
+    "sentiment_shift", "escalation_flag", "resolution_flag",
+]
+
+# --- Cached data ---
 _account_data: pd.DataFrame | None = None
+_agent1_data: pd.DataFrame | None = None
+_risk_cache: list[dict] | None = None  # pre-computed high-risk customers
 
 
 def load_account_data() -> pd.DataFrame:
-    """Load and join internet + customer data from S3, cache in memory."""
     global _account_data
     if _account_data is not None:
         return _account_data
 
-    # Load internet data
     obj = s3.get_object(Bucket=S3_BUCKET, Key="data/internet_data.csv")
     internet_df = pd.read_csv(io.BytesIO(obj["Body"].read()))
 
-    # Load customer data
     obj = s3.get_object(Bucket=S3_BUCKET, Key="data/trilink_customers_data.csv")
     customers_df = pd.read_csv(io.BytesIO(obj["Body"].read()))
 
-    # Join and index by customer_id
     merged = internet_df.merge(customers_df, on="customer_id", how="inner")
     _account_data = merged.set_index("customer_id")
     return _account_data
 
 
+def load_agent1_data() -> pd.DataFrame:
+    global _agent1_data
+    if _agent1_data is not None:
+        return _agent1_data
+    try:
+        obj = s3.get_object(Bucket=S3_BUCKET, Key="data/agent1_synthetic_output.csv")
+        _agent1_data = pd.read_csv(io.BytesIO(obj["Body"].read())).set_index("customer_id")
+    except Exception:
+        local_path = os.path.join(os.path.dirname(__file__), "../../sagemaker/churn/data/agent1_synthetic_output.csv")
+        if os.path.exists(local_path):
+            _agent1_data = pd.read_csv(local_path).set_index("customer_id")
+        else:
+            _agent1_data = pd.DataFrame()
+    return _agent1_data
+
+
+def encode_row(raw: dict) -> str:
+    """Encode a raw feature dict to CSV string for SageMaker."""
+    for col, mapping in LABEL_ENCODERS.items():
+        raw[col] = mapping.get(str(raw.get(col, "")), 0)
+    return ",".join(str(float(raw.get(col, 0))) for col in FEATURE_COLUMNS)
+
+
+def build_raw_features(customer: pd.Series, qa_score: float, sentiment: str,
+                       emotion_frustration: float, emotion_anger: float,
+                       sentiment_shift: float, escalation_flag: int,
+                       resolution_flag: int) -> dict:
+    """Build raw feature dict from account data + Agent 1 fields."""
+    return {
+        "plan_tier": customer["plan_tier"],
+        "speed_mbps": int(customer["speed_mbps"]),
+        "monthly_cost": float(customer["monthly_cost"]),
+        "data_usage_gb": float(customer["data_usage_gb"]),
+        "connected_devices": int(customer["connected_devices"]),
+        "contract_type": customer["contract_type"],
+        "speed_complaints": int(customer["speed_complaints"]),
+        "outage_count": int(customer["outage_count"]),
+        "internet_tenure_days": float(customer.get("internet_tenure_days", 0) or 0),
+        "contract_completed_percent": float(customer.get("contract_completed_percent", 0) or 0),
+        "age": int(customer["age"]),
+        "household_income": int(customer["household_income"]),
+        "income_bracket": customer["income_bracket"],
+        "family_size": int(customer["family_size"]),
+        "home_ownership": customer["home_ownership"],
+        "work_from_home_flag": str(customer["work_from_home_flag"]),
+        "education_level": customer["education_level"],
+        "life_stage": customer["life_stage"],
+        "home_type": customer["home_type"],
+        "home_square_footage": int(customer["home_square_footage"]),
+        "property_value": int(customer["property_value"]),
+        "neighborhood_crime_rate": float(customer["neighborhood_crime_rate"]),
+        "neighborhood_income_median": int(customer["neighborhood_income_median"]),
+        "fiber_availability": str(customer["fiber_availability"]),
+        "qa_score": qa_score,
+        "sentiment": sentiment,
+        "emotion_frustration": emotion_frustration,
+        "emotion_anger": emotion_anger,
+        "sentiment_shift": sentiment_shift,
+        "escalation_flag": escalation_flag,
+        "resolution_flag": resolution_flag,
+    }
+
+
+def compute_risk_cache() -> list[dict]:
+    """Batch-predict churn for all customers with call data.
+    Sends rows in batches to SageMaker (multi-row CSV) for speed."""
+    global _risk_cache
+    if _risk_cache is not None:
+        return _risk_cache
+
+    logger.info("Computing high-risk cache (batch prediction)...")
+    account_data = load_account_data()
+    agent1_data = load_agent1_data()
+
+    if agent1_data.empty:
+        _risk_cache = []
+        return _risk_cache
+
+    # Build all rows
+    customer_ids = []
+    csv_rows = []
+    metadata = []
+
+    for cid in agent1_data.index:
+        if cid not in account_data.index:
+            continue
+        customer = account_data.loc[cid]
+        call = agent1_data.loc[cid]
+
+        raw = build_raw_features(
+            customer,
+            float(call["qa_score"]), str(call["sentiment"]),
+            float(call["emotion_frustration"]), float(call["emotion_anger"]),
+            float(call["sentiment_shift"]), int(call["escalation_flag"]),
+            int(call["resolution_flag"]),
+        )
+        csv_rows.append(encode_row(raw))
+        customer_ids.append(cid)
+        metadata.append({
+            "plan": customer["plan_tier"],
+            "monthly_cost": int(customer["monthly_cost"]),
+            "contract_type": customer["contract_type"],
+            "sentiment": str(call["sentiment"]),
+            "qa_score": float(call["qa_score"]),
+            "emotion_frustration": float(call["emotion_frustration"]),
+            "emotion_anger": float(call["emotion_anger"]),
+        })
+
+    # Send in batches of 500 rows
+    BATCH_SIZE = 500
+    all_probas = []
+
+    for i in range(0, len(csv_rows), BATCH_SIZE):
+        batch = "\n".join(csv_rows[i:i + BATCH_SIZE])
+        try:
+            resp = sagemaker_runtime.invoke_endpoint(
+                EndpointName=ENDPOINT_NAME,
+                ContentType="text/csv",
+                Body=batch,
+            )
+            result = resp["Body"].read().decode().strip()
+            probas = [float(p) for p in result.split("\n")]
+            all_probas.extend(probas)
+        except Exception as e:
+            logger.error(f"Batch {i}-{i+BATCH_SIZE} failed: {e}")
+            all_probas.extend([0.0] * min(BATCH_SIZE, len(csv_rows) - i))
+
+    logger.info(f"Batch prediction complete: {len(all_probas)} customers scored")
+
+    # Build results
+    results = []
+    for j, proba in enumerate(all_probas):
+        if proba >= 0.4:  # only cache MEDIUM and HIGH risk
+            results.append({
+                "customer_id": customer_ids[j],
+                "churn_probability": round(proba, 4),
+                "risk_level": "HIGH" if proba >= 0.7 else "MEDIUM",
+                **metadata[j],
+            })
+
+    results.sort(key=lambda x: x["churn_probability"], reverse=True)
+    _risk_cache = results
+    logger.info(f"Risk cache built: {len(results)} at-risk customers")
+    return _risk_cache
+
+
 # --- Request / Response schemas ---
 class PredictRequest(BaseModel):
-    """Agent 1 output + customer_id. The wrapper looks up account data internally."""
     customer_id: str
-    qa_score: float = 5.0
-    sentiment: str = "Neutral"
-    emotion_frustration: float = 0.0
-    emotion_anger: float = 0.0
-    sentiment_shift: float = 0.0
-    escalation_flag: int = 0
-    resolution_flag: int = 1
+    qa_score: float | None = None
+    sentiment: str | None = None
+    emotion_frustration: float | None = None
+    emotion_anger: float | None = None
+    sentiment_shift: float | None = None
+    escalation_flag: int | None = None
+    resolution_flag: int | None = None
 
 
 class PredictResponse(BaseModel):
@@ -67,82 +247,133 @@ class PredictResponse(BaseModel):
     prediction: str
     risk_level: str
     customer_id: str
+    has_call_data: bool
+    qa_score: float
+    sentiment: str
+    emotion_frustration: float
+    emotion_anger: float
+    sentiment_shift: float
+    escalation_flag: int
+    resolution_flag: int
 
 
 # --- Routes ---
 @app.get("/health")
 def health():
-    return {
-        "status": "healthy",
-        "model": "churn-xgboost",
-        "endpoint": ENDPOINT_NAME,
+    return {"status": "healthy", "model": "churn-xgboost", "endpoint": ENDPOINT_NAME}
+
+
+@app.get("/customers")
+def list_customers(q: str = "", limit: int = 20):
+    """Search customers for the frontend dropdown."""
+    account_data = load_account_data()
+    agent1_data = load_agent1_data()
+    matches = account_data.index[account_data.index.str.contains(q, case=False)][:limit]
+    results = []
+    for cid in matches:
+        row = account_data.loc[cid]
+        has_call = cid in agent1_data.index
+        results.append({
+            "id": cid,
+            "label": f"{cid} — {row['plan_tier']}, {row['contract_type']}, ${int(row['monthly_cost'])}/mo"
+                     + (" (has call)" if has_call else ""),
+            "has_call": has_call,
+        })
+    return results
+
+
+@app.get("/customer-details/{customer_id}")
+def customer_details(customer_id: str):
+    """Return full account details for a customer. Used by the agent."""
+    account_data = load_account_data()
+    agent1_data = load_agent1_data()
+
+    if customer_id not in account_data.index:
+        raise HTTPException(status_code=404, detail=f"Customer {customer_id} not found")
+
+    c = account_data.loc[customer_id]
+    result = {
+        "customer_id": customer_id,
+        "plan_tier": c["plan_tier"],
+        "speed_mbps": int(c["speed_mbps"]),
+        "monthly_cost": float(c["monthly_cost"]),
+        "contract_type": c["contract_type"],
+        "internet_tenure_days": float(c.get("internet_tenure_days", 0) or 0),
+        "speed_complaints": int(c["speed_complaints"]),
+        "outage_count": int(c["outage_count"]),
+        "age": int(c["age"]),
+        "income_bracket": c["income_bracket"],
+        "home_ownership": c["home_ownership"],
+        "has_call_data": customer_id in agent1_data.index,
     }
+    if customer_id in agent1_data.index:
+        call = agent1_data.loc[customer_id]
+        result.update({
+            "qa_score": float(call["qa_score"]),
+            "sentiment": str(call["sentiment"]),
+            "emotion_frustration": float(call["emotion_frustration"]),
+            "emotion_anger": float(call["emotion_anger"]),
+        })
+    return result
+
+
+@app.get("/high-risk")
+def high_risk_customers(limit: int = 10):
+    """Return top N highest-risk customers from pre-computed cache."""
+    results = compute_risk_cache()
+    return results[:limit]
 
 
 @app.post("/predict", response_model=PredictResponse)
 def predict(req: PredictRequest):
     try:
-        # 1. Load account data
         account_data = load_account_data()
+        agent1_data = load_agent1_data()
 
-        # 2. Look up this customer
         if req.customer_id not in account_data.index:
-            raise HTTPException(
-                status_code=404,
-                detail=f"Customer {req.customer_id} not found",
-            )
+            raise HTTPException(status_code=404, detail=f"Customer {req.customer_id} not found")
 
         customer = account_data.loc[req.customer_id]
 
-        # 3. Build the full feature payload for SageMaker
-        payload = {
-            # Service features (from account lookup)
-            "plan_tier": customer["plan_tier"],
-            "speed_mbps": int(customer["speed_mbps"]),
-            "monthly_cost": float(customer["monthly_cost"]),
-            "data_usage_gb": float(customer["data_usage_gb"]),
-            "connected_devices": int(customer["connected_devices"]),
-            "contract_type": customer["contract_type"],
-            "speed_complaints": int(customer["speed_complaints"]),
-            "outage_count": int(customer["outage_count"]),
-            "internet_tenure_days": float(customer.get("internet_tenure_days", 0)),
-            "contract_completed_percent": float(customer.get("contract_completed_percent", 0)),
-            # Demographic features (from account lookup)
-            "age": int(customer["age"]),
-            "household_income": int(customer["household_income"]),
-            "income_bracket": customer["income_bracket"],
-            "family_size": int(customer["family_size"]),
-            "home_ownership": customer["home_ownership"],
-            "work_from_home_flag": str(customer["work_from_home_flag"]),
-            "education_level": customer["education_level"],
-            "life_stage": customer["life_stage"],
-            "home_type": customer["home_type"],
-            "home_square_footage": int(customer["home_square_footage"]),
-            "property_value": int(customer["property_value"]),
-            "neighborhood_crime_rate": float(customer["neighborhood_crime_rate"]),
-            "neighborhood_income_median": int(customer["neighborhood_income_median"]),
-            "fiber_availability": str(customer["fiber_availability"]),
-            # Agent 1 features (from request)
-            "qa_score": req.qa_score,
-            "sentiment": req.sentiment,
-            "emotion_frustration": req.emotion_frustration,
-            "emotion_anger": req.emotion_anger,
-            "sentiment_shift": req.sentiment_shift,
-            "escalation_flag": req.escalation_flag,
-            "resolution_flag": req.resolution_flag,
-        }
+        # Determine Agent 1 values: request > stored call data > neutral defaults
+        has_call = req.customer_id in agent1_data.index
+        call = agent1_data.loc[req.customer_id] if has_call else None
 
-        # 4. Call SageMaker
+        qa_score = req.qa_score if req.qa_score is not None else (float(call["qa_score"]) if call is not None else 5.0)
+        sentiment = req.sentiment if req.sentiment is not None else (str(call["sentiment"]) if call is not None else "Neutral")
+        emotion_frustration = req.emotion_frustration if req.emotion_frustration is not None else (float(call["emotion_frustration"]) if call is not None else 0.0)
+        emotion_anger = req.emotion_anger if req.emotion_anger is not None else (float(call["emotion_anger"]) if call is not None else 0.0)
+        sentiment_shift = req.sentiment_shift if req.sentiment_shift is not None else (float(call["sentiment_shift"]) if call is not None else 0.0)
+        escalation_flag = req.escalation_flag if req.escalation_flag is not None else (int(call["escalation_flag"]) if call is not None else 0)
+        resolution_flag = req.resolution_flag if req.resolution_flag is not None else (int(call["resolution_flag"]) if call is not None else 1)
+
+        raw = build_raw_features(customer, qa_score, sentiment, emotion_frustration,
+                                 emotion_anger, sentiment_shift, escalation_flag, resolution_flag)
+        csv_row = encode_row(raw)
+
         response = sagemaker_runtime.invoke_endpoint(
             EndpointName=ENDPOINT_NAME,
-            ContentType="application/json",
-            Body=json.dumps(payload),
+            ContentType="text/csv",
+            Body=csv_row,
         )
 
-        result = json.loads(response["Body"].read().decode())
+        proba = float(response["Body"].read().decode())
+        prediction = "churn" if proba >= 0.5 else "no_churn"
+        risk_level = "HIGH" if proba >= 0.7 else "MEDIUM" if proba >= 0.4 else "LOW"
+
         return PredictResponse(
             customer_id=req.customer_id,
-            **result,
+            churn_probability=round(proba, 4),
+            prediction=prediction,
+            risk_level=risk_level,
+            has_call_data=has_call or req.qa_score is not None,
+            qa_score=qa_score,
+            sentiment=sentiment,
+            emotion_frustration=emotion_frustration,
+            emotion_anger=emotion_anger,
+            sentiment_shift=sentiment_shift,
+            escalation_flag=escalation_flag,
+            resolution_flag=resolution_flag,
         )
 
     except HTTPException:


### PR DESCRIPTION
## Summary

### Performance — Batch Prediction Cache
- `/high-risk` now sends 500 rows per SageMaker call instead of 1-at-a-time
- Results cached after first compute — subsequent calls are instant
- ~20,571 customers scored in ~41 batch calls instead of 20,571 individual calls

### Agentic Improvements
- **4 tools** (was 2): get_customer_details, analyze_call, predict_churn, get_high_risk_customers
- **Conversation memory**: InMemoryChatMessageHistory persists across messages in a session
- **Intelligent routing**: agent decides which tools to use based on the question
- **Multi-step reasoning**: look up customer → predict churn → recommend action

### New API Endpoint
- `GET /customer-details/{customer_id}` — returns account info, plan, complaints, call data

### Rubric Coverage
- LangChain Agentic Harness: 4 tools, conditional routing, multi-step reasoning ✓
- Bedrock Chat Agent: conversation memory, autonomous tool selection ✓
- Non-trivial agentic behavior: agent chains tools and remembers context ✓

## Test plan
- [ ] `/high-risk?limit=5` returns results in <10 seconds (first call caches)
- [ ] `/customer-details/C00036458` returns account info
- [ ] Chat: "Tell me about C00036458" → agent uses get_customer_details + predict_churn
- [ ] Chat: follow-up question about same customer uses memory