### PR TITLE
Fix churn endpoint and add to Terraform

### DIFF
--- a/sagemaker/churn/deploy.py
+++ b/sagemaker/churn/deploy.py
@@ -33,14 +33,13 @@ EXECUTION_ROLE_ARN = os.environ.get(
 INSTANCE_TYPE = "ml.m5.large"
 
 # Model artifact paths (relative to this script)
+# IMPORTANT: Native XGBoost serving — tar.gz must contain ONLY the
+# xgboost-model binary. Including inference.py or JSON files causes
+# the container to try loading them as models and fail.
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 MODEL_FILES = [
     os.path.join(SCRIPT_DIR, "xgboost-model"),
-    os.path.join(SCRIPT_DIR, "label_encoders.json"),
-    os.path.join(SCRIPT_DIR, "feature_columns.json"),
 ]
-INFERENCE_SCRIPT = os.path.join(SCRIPT_DIR, "inference.py")
-SETUP_SCRIPT = os.path.join(SCRIPT_DIR, "setup.py")
 
 
 def package_model(tar_path: str) -> str:
@@ -49,8 +48,6 @@ def package_model(tar_path: str) -> str:
     with tarfile.open(tar_path, "w:gz") as tar:
         for filepath in MODEL_FILES:
             tar.add(filepath, arcname=os.path.basename(filepath))
-        # inference.py goes at the root of the tar alongside model files
-        tar.add(INFERENCE_SCRIPT, arcname="inference.py")
     print(f"  Created {tar_path}")
     return tar_path
 
@@ -72,17 +69,14 @@ def create_endpoint(s3_uri: str) -> None:
 
     # 1. Create SageMaker Model
     print(f"Creating SageMaker model: {MODEL_NAME}...")
+    container_config = {
+        "Image": f"683313688378.dkr.ecr.{REGION}.amazonaws.com/sagemaker-xgboost:1.7-1",
+        "ModelDataUrl": s3_uri,
+    }
     try:
         sm.create_model(
             ModelName=MODEL_NAME,
-            PrimaryContainer={
-                "Image": f"683313688378.dkr.ecr.{REGION}.amazonaws.com/sagemaker-xgboost:1.7-1",
-                "ModelDataUrl": s3_uri,
-                "Environment": {
-                    "SAGEMAKER_PROGRAM": "inference.py",
-                    "SAGEMAKER_SUBMIT_DIRECTORY": s3_uri,
-                },
-            },
+            PrimaryContainer=container_config,
             ExecutionRoleArn=EXECUTION_ROLE_ARN,
         )
     except sm.exceptions.ClientError as e:
@@ -91,13 +85,7 @@ def create_endpoint(s3_uri: str) -> None:
             sm.delete_model(ModelName=MODEL_NAME)
             sm.create_model(
                 ModelName=MODEL_NAME,
-                PrimaryContainer={
-                    "Image": f"683313688378.dkr.ecr.{REGION}.amazonaws.com/sagemaker-xgboost:1.7-1",
-                    "ModelDataUrl": s3_uri,
-                    "Environment": {
-                        "SAGEMAKER_PROGRAM": "inference.py",
-                    },
-                },
+                PrimaryContainer=container_config,
                 ExecutionRoleArn=EXECUTION_ROLE_ARN,
             )
         else:

--- a/terraform/sagemaker.tf
+++ b/terraform/sagemaker.tf
@@ -1,3 +1,36 @@
+# ── Churn Predictor Endpoint ───────────────────────────────────────────
+# Native XGBoost serving — no inference.py, no SAGEMAKER_PROGRAM.
+# The model.tar.gz must contain ONLY the xgboost-model binary file.
+# S3 path: s3://sagemaker-us-east-1-388691194728/models/churn/model.tar.gz
+
+resource "aws_sagemaker_model" "churn_model" {
+  name               = "churn-predictor-model"
+  execution_role_arn = "arn:aws:iam::388691194728:role/service-role/AmazonSageMaker-ExecutionRole-20260224T095369"
+
+  primary_container {
+    image          = "683313688378.dkr.ecr.us-east-1.amazonaws.com/sagemaker-xgboost:1.7-1"
+    model_data_url = "s3://sagemaker-us-east-1-388691194728/models/churn/model.tar.gz"
+  }
+}
+
+resource "aws_sagemaker_endpoint_configuration" "churn_endpoint_config" {
+  name = "churn-predictor-config"
+
+  production_variants {
+    variant_name           = "primary"
+    model_name             = aws_sagemaker_model.churn_model.name
+    initial_instance_count = 1
+    instance_type          = "ml.m5.large"
+  }
+}
+
+resource "aws_sagemaker_endpoint" "churn_endpoint" {
+  name                 = "churn-predictor-endpoint"
+  endpoint_config_name = aws_sagemaker_endpoint_configuration.churn_endpoint_config.name
+}
+
+# ── Sentiment Analysis Endpoint ───────────────────────────────────────
+
 resource "aws_sagemaker_model" "sentiment_model" {
   name               = "retention-sentiment-analysis-model"
   execution_role_arn = "arn:aws:iam::388691194728:role/retention/retention-sagemaker-execution-role"


### PR DESCRIPTION
## Summary
- Fixed churn `deploy.py` to use native XGBoost serving (no inference.py, no SAGEMAKER_PROGRAM) — matches the working deployment config
- Added churn endpoint resources to `sagemaker.tf` so both SageMaker endpoints are now Terraform-managed
- Prevents future breakage from Terraform apply overwriting manually deployed endpoints

## Test plan
- [x] Redeployed churn endpoint — returned `0.0111` churn probability (working)
- [x] Verified sentiment endpoint still InService
- [ ] Team: do not run `terraform apply` until this is merged (avoids state conflict)