### PR TITLE
Fix transcript speaker parsing and labels

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -680,20 +680,28 @@ function TranscribeTab() {
             {/* Speaker segments */}
             {selectedTranscript.segments.length > 0 ? (
               <div className="space-y-3 max-h-[calc(100vh-300px)] overflow-y-auto">
-                {selectedTranscript.segments.map((seg, i) => (
-                  <div key={i} className={`flex ${seg.speaker === "spk_0" ? "justify-start" : "justify-end"}`}>
-                    <div className={`max-w-[80%] rounded-xl px-4 py-3 ${
-                      seg.speaker === "spk_0"
-                        ? "bg-blue-50 text-blue-900 rounded-bl-sm"
-                        : "bg-gray-100 text-gray-800 rounded-br-sm"
-                    }`}>
-                      <span className="text-xs font-semibold block mb-1">
-                        {seg.speaker === "spk_0" ? "Agent" : "Customer"}
-                      </span>
-                      <p className="text-sm">{seg.text}</p>
+                {(() => {
+                  const uniqueSpeakers = new Set(selectedTranscript.segments.map(s => s.speaker));
+                  const hasTwoSpeakers = uniqueSpeakers.size >= 2;
+                  const speakerLabel = (spk: string) =>
+                    hasTwoSpeakers
+                      ? spk === "spk_0" ? "Agent" : "Customer"
+                      : "Speaker";
+                  return selectedTranscript.segments.map((seg, i) => (
+                    <div key={i} className={`flex ${hasTwoSpeakers && seg.speaker !== "spk_0" ? "justify-end" : "justify-start"}`}>
+                      <div className={`max-w-[80%] rounded-xl px-4 py-3 ${
+                        hasTwoSpeakers && seg.speaker !== "spk_0"
+                          ? "bg-gray-100 text-gray-800 rounded-br-sm"
+                          : "bg-blue-50 text-blue-900 rounded-bl-sm"
+                      }`}>
+                        <span className="text-xs font-semibold block mb-1">
+                          {speakerLabel(seg.speaker)}
+                        </span>
+                        <p className="text-sm">{seg.text}</p>
+                      </div>
                     </div>
-                  </div>
-                ))}
+                  ));
+                })()}
               </div>
             ) : (
               /* Full transcript fallback */

--- a/services/churn-predictor-api/app.py
+++ b/services/churn-predictor-api/app.py
@@ -442,17 +442,27 @@ def get_transcript(filename: str):
 
         full_text = result["results"]["transcripts"][0]["transcript"]
 
-        # Extract speaker segments if available
+        # Build speaker segments from top-level items (which have both
+        # speaker_label and alternatives with text content)
         segments = []
-        if "speaker_labels" in result["results"]:
-            for seg in result["results"]["speaker_labels"]["segments"]:
-                speaker = seg["speaker_label"]
-                text = " ".join(
-                    item["alternatives"][0]["content"]
-                    for item in seg["items"]
-                    if item.get("alternatives")
-                )
-                segments.append({"speaker": speaker, "text": text})
+        items = result["results"].get("items", [])
+        if items and items[0].get("speaker_label"):
+            current_speaker = None
+            current_words = []
+            for item in items:
+                speaker = item.get("speaker_label", current_speaker)
+                word = item["alternatives"][0]["content"] if item.get("alternatives") else ""
+                if speaker != current_speaker and current_words:
+                    segments.append({"speaker": current_speaker, "text": " ".join(current_words)})
+                    current_words = []
+                current_speaker = speaker
+                if word:
+                    if item.get("type") == "punctuation" and current_words:
+                        current_words[-1] += word
+                    else:
+                        current_words.append(word)
+            if current_words:
+                segments.append({"speaker": current_speaker, "text": " ".join(current_words)})
 
         return {
             "filename": filename,


### PR DESCRIPTION
## Summary
- Fix transcript API to read speaker text from top-level `items` array (where `alternatives` with text content lives) instead of `speaker_labels.segments` (which only has timestamps)
- Handle punctuation correctly (no extra spaces before commas/periods)
- Single-speaker transcripts labeled "Speaker" instead of incorrectly assuming "Agent"
- Two-speaker transcripts: spk_0 = Agent (speaks first), spk_1 = Customer

## Test plan
- [x] Verified against `sample_customer_call` transcript in S3
- [x] TypeScript compiles clean