### PR TITLE
Add safe teardown workflow and automate ALB controller install

### DIFF
--- a/.github/workflows/teardown.yml
+++ b/.github/workflows/teardown.yml
@@ -75,20 +75,37 @@ jobs:
       - name: Delete Ingress (triggers ALB cleanup)
         if: inputs.scope == 'all' || inputs.scope == 'kubernetes'
         run: |
+          echo "Capturing ALB details from Ingress before deletion..."
+          ALB_HOSTNAME=$(kubectl get ingress retention-engine-ingress -n retention-engine \
+            -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' 2>/dev/null || true)
+          ALB_NAME=""
+          if [ -n "$ALB_HOSTNAME" ]; then
+            ALB_NAME="${ALB_HOSTNAME%%.*}"
+            echo "Found ALB hostname: $ALB_HOSTNAME"
+            echo "Derived ALB name: $ALB_NAME"
+          else
+            echo "⚠️ No ALB hostname found on Ingress before deletion"
+          fi
+
           echo "Deleting Ingress — ALB controller will remove the ALB..."
           kubectl delete ingress retention-engine-ingress -n retention-engine --ignore-not-found
-          echo "Waiting for ALB to be deprovisioned..."
-          for i in $(seq 1 12); do
-            ALB=$(kubectl get ingress retention-engine-ingress -n retention-engine \
-              -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' 2>/dev/null || true)
-            if [ -z "$ALB" ]; then
-              echo "✅ ALB cleaned up"
-              break
-            fi
-            echo "  [$i/12] ALB still exists — waiting 10s..."
-            sleep 10
-          done
 
+          echo "Waiting for Ingress resource to be deleted from Kubernetes..."
+          kubectl wait --for=delete ingress/retention-engine-ingress -n retention-engine --timeout=120s 2>/dev/null || true
+
+          if [ -z "$ALB_NAME" ]; then
+            echo "⚠️ Skipping ALB polling because no ALB name could be determined"
+          else
+            echo "Waiting for ALB to be deprovisioned in AWS..."
+            for i in $(seq 1 12); do
+              if ! aws elbv2 describe-load-balancers --names "$ALB_NAME" >/dev/null 2>&1; then
+                echo "✅ ALB cleaned up"
+                break
+              fi
+              echo "  [$i/12] ALB still exists — waiting 10s..."
+              sleep 10
+            done
+          fi
       # ── Phase 2: Delete K8s namespace ─────────────────────────────
       - name: Delete K8s namespace
         if: inputs.scope == 'all' || inputs.scope == 'kubernetes'

--- a/.github/workflows/teardown.yml
+++ b/.github/workflows/teardown.yml
@@ -1,0 +1,164 @@
+# .github/workflows/teardown.yml
+# Safe teardown of AWS + K8s resources for full CI/CD pipeline testing
+# PRESERVES: EKS cluster, SageMaker endpoints, S3 bucket, sagemaker-execution-role
+#
+# After teardown, rebuild in order:
+#   1. terraform.yml  → apply (IAM roles, ALB controller IAM, transcribe Lambda)
+#   2. scripts/install-alb-controller.sh (manual — Helm install)
+#   3. sagemaker-deploy.yml → deploy both (no-op if endpoints exist)
+#   4. deploy.yml → all (build images, apply K8s, restart pods)
+
+name: 0 — Safe Teardown
+
+on:
+  workflow_dispatch:
+    inputs:
+      scope:
+        description: "What to tear down"
+        required: true
+        type: choice
+        options:
+          - all
+          - terraform
+          - kubernetes
+          - alb-controller
+        default: all
+      confirm:
+        description: "Type TEARDOWN to confirm (safety check)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  teardown:
+    runs-on: ubuntu-latest
+    steps:
+      # ── Safety Gate ───────────────────────────────────────────────
+      - name: Safety check
+        if: inputs.confirm != 'TEARDOWN'
+        run: |
+          echo "❌ Safety check failed — type TEARDOWN to confirm"
+          exit 1
+
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      # ── Tool Setup ────────────────────────────────────────────────
+      - name: Setup kubectl
+        if: inputs.scope == 'all' || inputs.scope == 'kubernetes' || inputs.scope == 'alb-controller'
+        uses: azure/setup-kubectl@v3
+
+      - name: Write kubeconfig
+        if: inputs.scope == 'all' || inputs.scope == 'kubernetes' || inputs.scope == 'alb-controller'
+        run: |
+          mkdir -p "$HOME/.kube"
+          echo "${{ secrets.KUBE_CONFIG }}" | base64 -d > "$HOME/.kube/config"
+
+      - name: Setup Helm
+        if: inputs.scope == 'all' || inputs.scope == 'alb-controller'
+        uses: azure/setup-helm@v4
+
+      - name: Setup Terraform
+        if: inputs.scope == 'all' || inputs.scope == 'terraform'
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.7"
+
+      # ── Phase 1: Delete Ingress (ALB controller cleans up the ALB) ─
+      - name: Delete Ingress (triggers ALB cleanup)
+        if: inputs.scope == 'all' || inputs.scope == 'kubernetes'
+        run: |
+          echo "Deleting Ingress — ALB controller will remove the ALB..."
+          kubectl delete ingress retention-engine-ingress -n retention-engine --ignore-not-found
+          echo "Waiting for ALB to be deprovisioned..."
+          for i in $(seq 1 12); do
+            ALB=$(kubectl get ingress retention-engine-ingress -n retention-engine \
+              -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' 2>/dev/null || true)
+            if [ -z "$ALB" ]; then
+              echo "✅ ALB cleaned up"
+              break
+            fi
+            echo "  [$i/12] ALB still exists — waiting 10s..."
+            sleep 10
+          done
+
+      # ── Phase 2: Delete K8s namespace ─────────────────────────────
+      - name: Delete K8s namespace
+        if: inputs.scope == 'all' || inputs.scope == 'kubernetes'
+        run: |
+          echo "Deleting retention-engine namespace and all resources..."
+          kubectl delete namespace retention-engine --ignore-not-found --timeout=120s
+          kubectl delete ingressclass alb --ignore-not-found
+          echo "✅ Kubernetes resources deleted"
+
+      # ── Phase 3: Uninstall ALB controller ─────────────────────────
+      - name: Uninstall ALB controller
+        if: inputs.scope == 'all' || inputs.scope == 'alb-controller'
+        run: |
+          if helm status aws-load-balancer-controller -n kube-system &>/dev/null; then
+            echo "Uninstalling ALB controller Helm release..."
+            helm uninstall aws-load-balancer-controller -n kube-system --wait
+            echo "✅ ALB controller uninstalled"
+          else
+            echo "⚠️ ALB controller not installed — skipping"
+          fi
+
+      # ── Phase 4: Terraform destroy (safe targets) ─────────────────
+      - name: Terraform Init
+        if: inputs.scope == 'all' || inputs.scope == 'terraform'
+        working-directory: terraform
+        run: terraform init
+
+      - name: Terraform destroy — IAM roles and policies
+        if: inputs.scope == 'all' || inputs.scope == 'terraform'
+        working-directory: terraform
+        run: |
+          echo "🔴 Destroying Terraform-managed resources..."
+          echo "   Preserving: S3 bucket, sagemaker-execution-role"
+          terraform destroy -var="environment=dev" -auto-approve \
+            -target=aws_iam_role_policy.bedrock_invoke_policy \
+            -target=aws_iam_role.bedrock_role \
+            -target=aws_iam_role_policy.sagemaker_invoke_policy \
+            -target=aws_iam_role.sagemaker_invoke_role \
+            -target=aws_iam_role_policy.sagemaker_featurestore_policy \
+            -target=aws_iam_role.sagemaker_featurestore_role \
+            -target=aws_iam_role_policy_attachment.alb_controller \
+            -target=aws_iam_role.alb_controller \
+            -target=aws_iam_policy.alb_controller \
+            -target=aws_iam_openid_connect_provider.eks \
+            -target=aws_s3_bucket_notification.audio_upload_trigger \
+            -target=aws_lambda_permission.allow_s3_invoke \
+            -target=aws_lambda_function.transcribe_pipeline \
+            -target=aws_iam_role_policy.transcribe_lambda_policy \
+            -target=aws_iam_role.transcribe_lambda_role
+          echo "✅ Terraform resources destroyed"
+
+      # ── Summary ───────────────────────────────────────────────────
+      - name: Teardown Summary
+        if: always()
+        run: |
+          echo "## 🧹 Teardown Complete" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Scope:** \`${{ inputs.scope }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### ✅ Preserved" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Resource | Reason |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|----------|--------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| EKS cluster \`eks-ezvrmopo-okl\` | Not managed by Terraform |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| SageMaker endpoints (churn + sentiment) | Not managed by Terraform |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| S3 bucket \`retention-engine-bucket\` | Contains training data |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| IAM role \`sagemaker-execution-role\` | Used by running endpoints |" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### 🔄 Rebuild Order" >> "$GITHUB_STEP_SUMMARY"
+          echo "1. **Terraform** → \`workflow_dispatch\` → action: \`apply\`, env: \`dev\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "2. **ALB Controller** → run \`scripts/install-alb-controller.sh\` locally" >> "$GITHUB_STEP_SUMMARY"
+          echo "3. **SageMaker** → \`workflow_dispatch\` → endpoint: \`both\`, action: \`deploy\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "4. **Deploy** → \`workflow_dispatch\` → service: \`all\`, tag: \`latest\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/teardown.yml
+++ b/.github/workflows/teardown.yml
@@ -3,10 +3,9 @@
 # PRESERVES: EKS cluster, SageMaker endpoints, S3 bucket, sagemaker-execution-role
 #
 # After teardown, rebuild in order:
-#   1. terraform.yml  → apply (IAM roles, ALB controller IAM, transcribe Lambda)
-#   2. scripts/install-alb-controller.sh (manual — Helm install)
-#   3. sagemaker-deploy.yml → deploy both (no-op if endpoints exist)
-#   4. deploy.yml → all (build images, apply K8s, restart pods)
+#   1. terraform.yml  → apply (IAM roles, ALB controller IAM + Helm install, transcribe Lambda)
+#   2. sagemaker-deploy.yml → deploy both (no-op if endpoints exist)
+#   3. deploy.yml → all (build images, apply K8s, restart pods)
 
 name: 0 — Safe Teardown
 
@@ -158,7 +157,6 @@ jobs:
           echo "| IAM role \`sagemaker-execution-role\` | Used by running endpoints |" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "### 🔄 Rebuild Order" >> "$GITHUB_STEP_SUMMARY"
-          echo "1. **Terraform** → \`workflow_dispatch\` → action: \`apply\`, env: \`dev\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "2. **ALB Controller** → run \`scripts/install-alb-controller.sh\` locally" >> "$GITHUB_STEP_SUMMARY"
-          echo "3. **SageMaker** → \`workflow_dispatch\` → endpoint: \`both\`, action: \`deploy\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "4. **Deploy** → \`workflow_dispatch\` → service: \`all\`, tag: \`latest\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "1. **Terraform** → \`workflow_dispatch\` → action: \`apply\`, env: \`dev\` (includes ALB controller Helm install)" >> "$GITHUB_STEP_SUMMARY"
+          echo "2. **SageMaker** → \`workflow_dispatch\` → endpoint: \`both\`, action: \`deploy\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "3. **Deploy** → \`workflow_dispatch\` → service: \`all\`, tag: \`latest\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/teardown.yml
+++ b/.github/workflows/teardown.yml
@@ -149,7 +149,6 @@ jobs:
             -target=aws_iam_role_policy_attachment.alb_controller \
             -target=aws_iam_role.alb_controller \
             -target=aws_iam_policy.alb_controller \
-            -target=aws_iam_openid_connect_provider.eks \
             -target=aws_s3_bucket_notification.audio_upload_trigger \
             -target=aws_lambda_permission.allow_s3_invoke \
             -target=aws_lambda_function.transcribe_pipeline \

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -70,3 +70,46 @@ jobs:
       - name: Print Outputs
         if: inputs.action == 'apply'
         run: terraform output
+
+      # ── ALB Controller Helm Install (after apply) ─────────────────
+      - name: Setup kubectl
+        if: inputs.action == 'apply'
+        uses: azure/setup-kubectl@v3
+
+      - name: Setup Helm
+        if: inputs.action == 'apply'
+        uses: azure/setup-helm@v4
+
+      - name: Write kubeconfig
+        if: inputs.action == 'apply'
+        run: |
+          mkdir -p "$HOME/.kube"
+          echo "${{ secrets.KUBE_CONFIG }}" | base64 -d > "$HOME/.kube/config"
+
+      - name: Install ALB Controller
+        if: inputs.action == 'apply'
+        run: |
+          CLUSTER_NAME="eks-ezvrmopo-okl"
+          REGION="${{ secrets.AWS_REGION }}"
+          ROLE_ARN=$(terraform output -raw alb_controller_role_arn)
+          echo "ALB Controller Role ARN: $ROLE_ARN"
+
+          helm repo add eks https://aws.github.io/eks-charts
+          helm repo update
+
+          VPC_ID=$(aws eks describe-cluster --name "$CLUSTER_NAME" \
+            --query 'cluster.resourcesVpcConfig.vpcId' --output text)
+
+          helm upgrade --install aws-load-balancer-controller eks/aws-load-balancer-controller \
+            --namespace kube-system \
+            --set clusterName="$CLUSTER_NAME" \
+            --set region="$REGION" \
+            --set vpcId="$VPC_ID" \
+            --set serviceAccount.create=true \
+            --set serviceAccount.name=aws-load-balancer-controller \
+            --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"="$ROLE_ARN"
+
+          echo "Waiting for controller to be ready..."
+          kubectl rollout status deployment/aws-load-balancer-controller \
+            -n kube-system --timeout=120s
+          echo "✅ ALB Controller installed"

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -73,23 +73,23 @@ jobs:
 
       # ── ALB Controller Helm Install (after apply) ─────────────────
       - name: Setup kubectl
-        if: inputs.action == 'apply'
+        if: inputs.action == 'apply' && inputs.environment == 'dev'
         uses: azure/setup-kubectl@v3
 
       - name: Setup Helm
-        if: inputs.action == 'apply'
+        if: inputs.action == 'apply' && inputs.environment == 'dev'
         uses: azure/setup-helm@v4
 
       - name: Write kubeconfig
-        if: inputs.action == 'apply'
+        if: inputs.action == 'apply' && inputs.environment == 'dev'
         run: |
           mkdir -p "$HOME/.kube"
           echo "${{ secrets.KUBE_CONFIG }}" | base64 -d > "$HOME/.kube/config"
 
       - name: Install ALB Controller
-        if: inputs.action == 'apply'
+        if: inputs.action == 'apply' && inputs.environment == 'dev'
         run: |
-          CLUSTER_NAME="eks-ezvrmopo-okl"
+          CLUSTER_NAME=$(kubectl config view --minify -o jsonpath='{.contexts[0].context.cluster}')
           REGION="${{ secrets.AWS_REGION }}"
           ROLE_ARN=$(terraform output -raw alb_controller_role_arn)
           echo "ALB Controller Role ARN: $ROLE_ARN"


### PR DESCRIPTION
## What

- **New workflow: `0 — Safe Teardown`** (`teardown.yml`) — tears down AWS + K8s resources for CI/CD pipeline testing
- **Automates ALB controller Helm install** in `terraform.yml` after `terraform apply`

## Teardown Workflow

Manual `workflow_dispatch` with safety gate (must type TEARDOWN to confirm).

**Scope options:** `all` | `terraform` | `kubernetes` | `alb-controller`

**Preserved:** EKS cluster, SageMaker endpoints, S3 bucket, `sagemaker-execution-role`

## ALB Controller Automation

Moved from manual `scripts/install-alb-controller.sh` into `terraform.yml` post-apply step.

## Full CI/CD Pipeline (3 clicks, zero manual steps)

1. **Terraform** → apply, dev (IAM + ALB controller Helm)
2. **SageMaker** → both, deploy
3. **Deploy** → all, latest