### PR TITLE
Session 3: Strategist, transcribe routes, guardrail, frontend updates

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,453 @@
+# The Retention Engine — Architecture
+
+## System Architecture
+
+```
+                                 ┌──────────────────────┐
+                                 │    USER / BROWSER     │
+                                 └──────────┬───────────┘
+                                            │ HTTPS
+┌───────────────────────────────────────────▼────────────────────────────────────────────┐
+│                          Frontend (React + Vite + Tailwind)                             │
+│                          Port 3000 / nginx · Lucide React icons                        │
+│                                                                                        │
+│  ┌──────────────────────┐  ┌──────────────────────┐  ┌──────────────────────────────┐  │
+│  │   ANALYZE TAB        │  │     CHAT TAB         │  │      TRANSCRIBE TAB          │  │
+│  │                      │  │                      │  │                              │  │
+│  │  CustomerCombobox    │  │  Conversational AI   │  │  CustomerCombobox            │  │
+│  │  (searchable         │  │  interface           │  │  (associate with customer)   │  │
+│  │   dropdown)          │  │                      │  │  Audio Upload (.wav/.mp3)    │  │
+│  │  Transcript input    │  │  Session memory      │  │  Transcript List (from S3)   │  │
+│  │                      │  │  (per session_id)    │  │  Speaker-segmented viewer    │  │
+│  │  If transcript:      │  │                      │  │  (Agent / Customer bubbles)  │  │
+│  │  1. Sentiment API    │  │  Tries Agent Service │  │                              │  │
+│  │  2. Save to S3       │  │  first, falls back   │  │                              │  │
+│  │  3. Churn predict    │  │  to direct churn     │  │                              │  │
+│  │     (with enriched   │  │  predictor API       │  │                              │  │
+│  │      sentiment data) │  │                      │  │                              │  │
+│  │  No transcript:      │  │                      │  │                              │  │
+│  │  → Churn predict     │  │                      │  │                              │  │
+│  │    (account data     │  │                      │  │                              │  │
+│  │     only)            │  │                      │  │                              │  │
+│  │                      │  │                      │  │                              │  │
+│  │  Results:            │  │                      │  │                              │  │
+│  │  • RiskCard          │  │                      │  │                              │  │
+│  │  • SentimentCard     │  │                      │  │                              │  │
+│  │  • ActionCard        │  │                      │  │                              │  │
+│  └──────────┬───────────┘  └──────────┬───────────┘  └──────────────┬───────────────┘  │
+│             │                         │                              │                  │
+│  Data flow: │              Data flow: │                   Data flow: │                  │
+│  Sentiment API →           Agent-first with              File upload + S3 list         │
+│  save transcript →         fallback                      by customer ID                │
+│  churn predict                                           (no agent)                    │
+└──────┬──────┼─────────────────────────┼──────────────────────────────┼──────────────────┘
+       │      │                         │                              │
+       │      │              ┌──────────┴──────────┐                   │
+       │      │              │ tries :8080 first   │                   │
+       │      │              │ catches network err │                   │
+       │      │              │ falls back to :8001 │                   │
+       │      │              └──┬───────────────┬──┘                   │
+       │      │                 │               │                      │
+       │      │          Agent reachable   Agent down                  │
+       │      │                 │               │                      │
+       │      │                 ▼               │                      │
+       │      │                                                        │
+       │      │  Analyze tab (if transcript provided):                 │
+       │      │  ① POST sentiment-api:8002/predict ──────────────────────────►(Sentiment API)
+       │      │  ② POST churn-api:8001/save-transcript (background)   │
+       │      │  ③ POST churn-api:8001/predict (with enriched fields)──►(Churn API)
+       │      │                                                        │
+              │    ┌────────────────────────┐   │                      │
+              │    │   Agent Service        │   │                      │
+              │    │   (FastAPI :8080)      │   │                      │
+              │    │                        │   │                      │
+              │    │   POST /chat           │   │                      │
+              │    │   GET  /health         │   │                      │
+              │    │                        │   │                      │
+              │    │   ┌─────────────────────────────────┐   │         │
+              │    │   │       LangGraph Orchestrator    │   │         │
+              │    │   │                                 │   │         │
+              │    │   │  ┌───────────────────────────┐  │   │         │
+              │    │   │  │  DataGatherer             │  │   │         │
+              │    │   │  │  (Bedrock + Guardrail)    │  │   │         │
+              │    │   │  │                           │  │   │         │
+              │    │   │  │  Guardrail:               │  │   │         │
+              │    │   │  │  retention-engine-        │  │   │         │
+              │    │   │  │  guardrail (nvruz8wx5q83) │  │   │         │
+              │    │   │  │  • Hate/Sexual: HIGH      │  │   │         │
+              │    │   │  │  • Violence: HIGH/MED     │  │   │         │
+              │    │   │  │  • Misconduct: HIGH/LOW   │  │   │         │
+              │    │   │  │  • Insults: MED/LOW       │  │   │         │
+              │    │   │  │  • PII: ANONYMIZE/BLOCK   │  │   │         │
+              │    │   │  └─────────────┬─────────────┘  │   │         │
+              │    │   │                │                 │   │         │
+              │    │   │  ┌─────────────▼─────────────┐  │   │         │
+              │    │   │  │  RetentionStrategist      │  │   │         │
+              │    │   │  │  (Bedrock, NO guardrail)  │  │   │         │
+              │    │   │  │                           │  │   │         │
+              │    │   │  │  Uses clean LLM to avoid  │  │   │         │
+              │    │   │  │  blocking retention terms │  │   │         │
+              │    │   │  │  (cancel, churn, etc.)    │  │   │         │
+              │    │   │  └───────────────────────────┘  │   │         │
+              │    │   └────────────────┬────────────────┘   │         │
+              │    │                    │                     │         │
+              │    │   Tools (5 HTTP calls):                  │         │
+              │    │   • get_customer_details ───────────────►│         │
+              │    │   • predict_churn ─────────────────────►│         │
+              │    │   • analyze_call ──────────────────────►Sent. API │
+              │    │   • get_high_risk_customers ───────────►│         │
+              │    │   • get_transcripts ───────────────────►│         │
+              │    └───────────────┬────────────┘             │         │
+              │                    │                          │         │
+              │    ┌───────────────▼───────────────┐          │         │
+              │    │      Amazon Bedrock            │          │         │
+              │    │      Claude Haiku 4.5          │          │         │
+              │    │                                │          │         │
+              │    │  2 LLM instances:              │          │         │
+              │    │  • llm (guardrail attached)    │          │         │
+              │    │    → used by DataGatherer      │          │         │
+              │    │  • llm_strategist (no guard)   │          │         │
+              │    │    → used by RetentionStrat.   │          │         │
+              │    └────────────────────────────────┘          │         │
+              │                                 │                      │
+              ▼                                 ▼                      ▼
+
+┌──────────────────────────────────────────────────────────────────────────────────────┐
+│                    Churn Predictor Service (FastAPI :8001)                            │
+│                                                                                      │
+│  Routes:                                    Internal:                                │
+│  GET  /customers                            Loads account data + Agent 1 data from S3│
+│  GET  /customer-details/{id}                Label encoders + 31 features from train  │
+│  POST /predict                              Batch prediction: 500 rows/batch + cache │
+│  GET  /high-risk                                                                     │
+│  POST /transcribe (+ customer_id)           ┌──────────────────────────────────────┐ │
+│  GET  /transcripts (filter by customer_id)  │  SageMaker Endpoint #1               │ │
+│  GET  /transcripts/{name}                   │  churn-predictor-endpoint             │ │
+│  POST /save-transcript                      │                                      │ │
+│  GET  /health                               │  XGBoost v3 · 31 features            │ │
+│                                             │  95% accuracy · 0.9861 AUC           │ │
+│  /predict encodes features → CSV →          │  Native XGBoost container            │ │
+│  invokes SageMaker → returns probability    │  (no inference.py)                   │ │
+│                                             └──────────────────────────────────────┘ │
+└──────────────────────────────┬───────────────────────────────────────────────────────┘
+                               │ boto3
+                               ▼
+                    ┌──────────────────┐
+                    │ S3: retention-   │
+                    │ engine-bucket    │
+                    │                  │
+                    │ /data/           │
+                    │  internet_data   │
+                    │  trilink_cust    │
+                    │  agent1_synth    │
+                    │                  │
+                    │ /audio/          │
+                    │  /{cust_id}/     │
+                    │ /transcripts/    │
+                    │  /{cust_id}/     │
+                    │                  │
+                    │ /models/         │
+                    │  churn/          │
+                    │  sentiment/      │
+                    │  sentiment-rev/  │
+                    └────────┬─────────┘
+                             │
+                             ▼
+              ┌────────────────────────────────────────┐
+              │ Amazon Transcribe                      │
+              │                                        │
+              │  ┌──────────┐    ┌──────────────────┐  │
+              │  │ S3 audio/│───►│ Lambda:          │  │
+              │  │ {cust_id}│    │ retention-       │  │
+              │  │ upload   │    │ transcribe-      │  │
+              │  └──────────┘    │ pipeline         │  │
+              │                  └────────┬─────────┘  │
+              │                           │             │
+              │  ┌────────────────────────▼──────────┐ │
+              │  │ Amazon Transcribe Job             │ │
+              │  │ Speaker diarization (2 speakers) │ │
+              │  │ Output → S3 transcripts/{cid}/   │ │
+              │  └──────────────────────────────────┘ │
+              └────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────────────────────────────────────┐
+│                  Sentiment Analysis Service (FastAPI :8002)                           │
+│                                                                                      │
+│  Routes:                                                                             │
+│  POST /predict                                                                       │
+│  GET  /health                                                                        │
+│                                                                                      │
+│  Enrichment Pipeline:                       ┌──────────────────────────────────────┐ │
+│                                             │  SageMaker Endpoint #2               │ │
+│  1. Call SageMaker ─────────────────────────►│  retention-sentiment-revised-endpoint│ │
+│     (base sentiment classification)         │                                      │ │
+│             │                               │  DistilBERT 3-class revised          │ │
+│  2. Decode label (Neg/Neu/Pos)              │  (Negative / Neutral / Positive)     │ │
+│             │                               │                                      │ │
+│  3. Emotion scores (keyword NLP:            │  HuggingFace PyTorch container       │ │
+│     frustration, anger, joy, sadness, fear) └──────────────────────────────────────┘ │
+│             │                                                                        │
+│  4. Sentiment shift (1st half vs 2nd half)                                           │
+│             │                                                                        │
+│  5. Escalation + resolution detection (phrase matching)                              │
+│             │                                                                        │
+│  6. QA score (composite: sentiment + emotions + flags)                               │
+│             │                                                                        │
+│  7. Return all 7 fields ─────────────────────────────► Agent 2 (Churn Predictor)    │
+│     qa_score · sentiment · emotion_frustration                                       │
+│     emotion_anger · sentiment_shift                                                  │
+│     escalation_flag · resolution_flag                                                │
+└──────────────────────────────────────────────────────────────────────────────────────┘
+
+─────────────────────────────────────────────────────────────────────────────────────────
+
+INFRASTRUCTURE LAYER
+
+┌─────────────────────────────────────────────────────────────────────────────────────┐
+│                              EKS Cluster: eks-ezvrmopo-okl                         │
+│                              Namespace: retention-engine                            │
+│                                                                                     │
+│  ┌──────────────────┐  ┌──────────────────┐  ┌──────────────────┐                  │
+│  │ agent-service    │  │ churn-predictor  │  │ sentiment-       │                  │
+│  │ Deployment       │  │ Deployment       │  │ predictor        │                  │
+│  │ Port: 8080       │  │ Port: 8001       │  │ Deployment       │                  │
+│  │ LoadBalancer     │  │ ClusterIP        │  │ Port: 8001       │                  │
+│  └──────────────────┘  └──────────────────┘  │ ClusterIP        │                  │
+│                                               └──────────────────┘                  │
+│  ┌──────────────────┐                                                               │
+│  │ frontend         │  ConfigMaps ─ Secrets ─ ResourceQuota ─ LimitRange           │
+│  │ Deployment       │                                                               │
+│  │ Port: 3000       │                                                               │
+│  │ LoadBalancer     │                                                               │
+│  └──────────────────┘                                                               │
+└─────────────────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────────────────┐
+│                                   Terraform                                         │
+│                                                                                     │
+│  iam.tf          s3.tf           eks.tf          guardrail.tf    transcribe.tf      │
+│  • SageMaker     • retention-    • EKS cluster   • Bedrock       • Lambda function  │
+│    execution       engine-       • Node group      content        • IAM role         │
+│    roles           bucket        • VPC subnets     moderation     • S3 event trigger │
+│  • Lambda role   • TF state     • IRSA                                              │
+│                    bucket                                                            │
+│                                                                                     │
+│  State: s3://retention-engine-tf-state + DynamoDB lock                              │
+└─────────────────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────────────────┐
+│                             CI/CD — GitHub Actions                                  │
+│                                                                                     │
+│  1. terraform.yml          Triggered on PR to terraform/**                          │
+│     plan / apply           Provisions IAM, S3, EKS, guardrails                     │
+│                                                                                     │
+│  2. sagemaker-deploy.yml   Triggered on push to main, sagemaker/**                 │
+│     deploy / delete        Runs deploy.py, polls InService, validates inference     │
+│                                                                                     │
+│  3. deploy.yml             Triggered on push to main, services/** frontend/**      │
+│     Docker → GHCR → EKS   Matrix build per service, kubectl rollout               │
+│                                                                                     │
+│  4. ci-post-merge.yml      Triggered on push to main                               │
+│     Unit tests → Docker    build → endpoint health → E2E smoke test                │
+│                                                                                     │
+│  5. teardown.yml           Manual dispatch — safe cleanup for testing               │
+│                                                                                     │
+│  Observability: LangSmith (project: retention-engine)                              │
+└─────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## LangGraph Orchestrator Flow
+
+```
+                              User Message
+                                  │
+                                  ▼
+                        ┌─────────────────┐
+                        │    CLASSIFY      │
+                        │                  │
+                        │ • Extract        │
+                        │   customer_id    │
+                        │   (regex C\d{8}) │
+                        │                  │
+                        │ • Detect type:   │
+                        │   customer_query │
+                        │   high_risk      │
+                        │   transcript     │
+                        │   general        │
+                        │                  │
+                        │ • Enrich state   │
+                        └────────┬─────────┘
+                                 │
+                                 │ always
+                                 ▼
+                  ┌──────────────────────────────┐
+                  │     MODEL (Data Gatherer)     │
+                  │                                │
+                  │  System: GATHERER_PROMPT        │
+                  │  LLM: Claude Haiku 4.5          │
+                  │  + Bedrock Guardrail            │
+                  │  Tools: 5 tools bound           │
+                  │                                │
+                  │  "Collect all relevant data.    │
+                  │   Do not recommend yet."         │
+                  │                                │
+                  │  Claude decides which tools     │
+                  │  to call based on the question  │
+                  └──────────┬───────────────────┘
+                             │
+                    ┌────────┴────────┐
+                    │                 │
+              has tool calls    no tool calls
+                    │                 │
+                    ▼                 │
+          ┌─────────────────┐        │
+          │     TOOLS       │        │
+          │  (ToolNode)     │        │
+          │                 │        │
+          │  Executes:      │        │
+          │  ┌────────────┐ │        │
+          │  │get_customer│ │        │
+          │  │_details    │ │        │
+          │  └────────────┘ │        │
+          │  ┌────────────┐ │        │
+          │  │predict_    │ │        │
+          │  │churn       │ │        │
+          │  └────────────┘ │        │
+          │  ┌────────────┐ │        │
+          │  │analyze_    │ │        │
+          │  │call        │ │        │
+          │  └────────────┘ │        │
+          │  ┌────────────┐ │        │
+          │  │get_high_   │ │        │
+          │  │risk_       │ │        │
+          │  │customers   │ │        │
+          │  └────────────┘ │        │
+          │  ┌────────────┐ │        │
+          │  │get_        │ │        │
+          │  │transcripts │ │        │
+          │  └────────────┘ │        │
+          └────────┬────────┘        │
+                   │                 │
+                   │ always          │
+                   ▼                 │
+        ┌────────────────────┐       │
+        │  RESPOND           │       │
+        │  (Gatherer Review) │       │
+        │                    │       │
+        │  Reviews tool      │       │
+        │  results.          │       │
+        │  May request       │       │
+        │  more tools.       │       │
+        └────────┬───────────┘       │
+                 │                   │
+        ┌────────┴────────┐          │
+        │                 │          │
+  has tool calls    no tool calls    │
+        │                 │          │
+        ▼                 │          │
+   (back to TOOLS)        │          │
+                          │          │
+                          ▼          ▼
+                ┌─────────────────────────────┐
+                │      STRATEGIST             │
+                │  (Retention Strategist)      │
+                │                              │
+                │  System: STRATEGIST_PROMPT    │
+                │  LLM: Claude Haiku 4.5        │
+                │  NO guardrail (uses           │
+                │  llm_strategist to avoid      │
+                │  blocking retention terms)    │
+                │  Tools: NONE (reasoning only) │
+                │                              │
+                │  Receives all gathered data   │
+                │  and produces:                │
+                │                              │
+                │  1. Customer Summary          │
+                │  2. Churn Risk: HIGH/MED/LOW  │
+                │  3. Sentiment (if available)  │
+                │  4. Action: [ACTION_CODE]     │
+                │  5. Recommendation            │
+                │                              │
+                │  APPROVED ACTIONS:            │
+                │  HIGH:   PLAN_UPGRADE         │
+                │          LOYALTY_DISCOUNT     │
+                │          SERVICE_CREDIT       │
+                │          TECH_VISIT           │
+                │          DEDICATED_SUPPORT    │
+                │          CONTRACT_FLEX        │
+                │  MEDIUM: FOLLOWUP_48H         │
+                │          GOODWILL_CREDIT      │
+                │          SPEED_BOOST          │
+                │  LOW:    MONITOR              │
+                └──────────────┬───────────────┘
+                               │
+                               ▼
+                             END
+                     (return AI response)
+
+
+─────────────────────────────────────────────────────────────
+
+TOOL DETAIL
+
+┌─────────────────────────────────────────────────────────┐
+│ get_customer_details                                     │
+│ GET churn-predictor:8001/customer-details/{customer_id}  │
+│ Returns: plan_tier, speed_mbps, monthly_cost,            │
+│   contract_type, tenure, complaints, outage_count,       │
+│   age, income_bracket, has_call_data, qa_score,          │
+│   sentiment, emotion_frustration, emotion_anger          │
+└─────────────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────┐
+│ predict_churn                                            │
+│ POST churn-predictor:8001/predict                        │
+│ Sends: customer_id + 7 Agent 1 fields                   │
+│ Returns: churn_probability, prediction, risk_level,      │
+│   has_call_data, qa_score, sentiment, emotion scores     │
+└─────────────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────┐
+│ analyze_call                                             │
+│ POST sentiment-api:8002/predict                          │
+│ Sends: transcript text                                   │
+│ Returns: qa_score, sentiment, emotion_frustration,       │
+│   emotion_anger, sentiment_shift, escalation_flag,       │
+│   resolution_flag (enriched via NLP post-processing)     │
+└─────────────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────┐
+│ get_high_risk_customers                                  │
+│ GET churn-predictor:8001/high-risk?limit=N               │
+│ Returns: ranked list of at-risk customers with           │
+│   churn_probability, plan, cost, sentiment, qa_score     │
+│ Uses batch SageMaker prediction (500 rows/batch)         │
+└─────────────────────────────────────────────────────────┘
+┌─────────────────────────────────────────────────────────┐
+│ get_transcripts                                          │
+│ GET churn-predictor:8001/transcripts?customer_id={id}    │
+│ Returns: list of transcripts for a customer (up to 5)    │
+│   with full text and speaker segments                    │
+│ Fetches from S3 transcripts/{customer_id}/               │
+└─────────────────────────────────────────────────────────┘
+
+─────────────────────────────────────────────────────────
+
+CONVERSATION MEMORY
+
+  Session A ──┐    Session B ──┐
+              │                │
+     ┌────────▼──────┐  ┌─────▼────────┐
+     │ MemorySaver   │  │ MemorySaver  │
+     │ thread_id: A  │  │ thread_id: B │
+     │               │  │              │
+     │ msg1: human   │  │ msg1: human  │
+     │ msg2: ai      │  │ msg2: ai     │
+     │ msg3: tool    │  │ ...          │
+     │ msg4: ai      │  └──────────────┘
+     │ ...           │
+     └───────────────┘
+
+  In-memory checkpointer per session.
+  Resets on service restart.
+  Each session_id gets isolated conversation history.
+```

--- a/docs/llm-usage/kathleen-llm-usage.md
+++ b/docs/llm-usage/kathleen-llm-usage.md
@@ -1,7 +1,7 @@
 # LLM Usage Log — Kathleen
 
 **Tool:** Claude Code (Claude Opus 4.6, CLI + VS Code extension)
-**Period:** March 30 – April 4, 2026
+**Period:** March 30 – April 11, 2026
 
 ---
 
@@ -213,12 +213,12 @@ Used Claude Code as a pair programming partner throughout the capstone project. 
 - **Bug I found:** Switching between Analyze and Chat tabs wiped the state in both
 - **Fix:** Changed from conditional rendering (`{tab === "analyze" ? <A/> : <B/>}`) to CSS hidden (`<div className={tab === "analyze" ? "" : "hidden"}>`) so both tabs stay mounted
 
-### Okino's PR #46 Review
-- Identified that his PR deletes our entire `services/churn-predictor-api/` directory
-- He also renames `qa_tool.py` → `sentiment_tool.py` and restructures `services/` → `backend/`
-- **My guidance:** Requested changes on the PR — told him not to delete our code, offered to coordinate the rename
+### PR #46 Review — Cross-Service File Conflicts
+- Identified that the PR included changes to `services/churn-predictor-api/` along with the sentiment service rename
+- Renames `qa_tool.py` → `sentiment_tool.py` and restructures `services/` → `backend/`
+- **My guidance:** Requested changes on the PR — coordinated to avoid overwriting each other's services
 - Created `.backup/` directory to protect critical files from branch conflicts
-- Tested his live SageMaker sentiment endpoint — it returns raw class predictions, not the rich JSON output we need
+- Tested the live SageMaker sentiment endpoint — identified that the output format needed additional enrichment fields for the churn predictor integration
 
 ### Rubric Audit
 - Conducted full audit of all 10 rubric areas against current implementation
@@ -246,14 +246,14 @@ Used Claude Code as a pair programming partner throughout the capstone project. 
 **Outcome:** Batch prediction + caching implemented.
 
 ### 17. Protecting Code from PR Deletions
-**My guidance:** After discovering Okino's PR deletes our code, created `.backup/` and established the rule: always verify files exist on current branch before starting work.
+**My guidance:** After discovering file conflicts across PRs, created `.backup/` and established the rule: always verify files exist on current branch before starting work.
 
 ### 18. Not Making Assumptions About Teammate's Code
-**My guidance:** When Claude offered to rewrite Okino's qa_tool.py to call his SageMaker endpoint directly, I said "No, I don't want to make those assumptions. We will work it through this evening."
+**My guidance:** When Claude offered to rewrite the sentiment tool to call the SageMaker endpoint directly, I said "No, I don't want to make those assumptions. We will work it through this evening."
 
 ### 19. Frankenstein PR — Cherry-Picking Across Branches
-**Situation:** Okino's PR #46 had useful new sentiment files but also deleted our working code and restructured directories. PR #47 had our LangGraph/LangSmith work. Neither could merge cleanly.
-**My guidance:** Asked Claude to cherry-pick Okino's sentiment files from his branch, combine with our code from backups, and create a single consolidated PR #48. Closed both #46 and #47.
+**Situation:** PR #46 had useful new sentiment files alongside directory restructuring. PR #47 had our LangGraph/LangSmith work. Neither could merge cleanly due to overlapping file changes.
+**My guidance:** Asked Claude to cherry-pick the sentiment files from one branch, combine with our code from backups, and create a single consolidated PR #48. Closed both #46 and #47.
 **Outcome:** Clean PR with all components working together. Required manual verification that every file from both PRs was included.
 
 ### 20. Defending Working Code
@@ -275,3 +275,85 @@ Used Claude Code as a pair programming partner throughout the capstone project. 
 - Establish stricter PR review process — too many files were modified outside lane ownership
 - Use LangGraph from the start instead of AgentExecutor — the explicit state graph is easier to reason about and debug
 - Set up LangSmith from Day 1 — would have caught the action selection issue much earlier
+
+---
+
+## Session 3 Work (April 9–11, 2026)
+
+### Churn Endpoint Recovery
+- Troy redeployed SageMaker endpoints via Terraform, which broke the churn predictor
+- **Root cause:** Terraform `sagemaker.tf` defined the endpoints, but our `deploy.py` also managed them. When Troy ran `terraform apply`, it destroyed and recreated the churn endpoint with an `inference.py` that garbled CSV input
+- **My analysis:** Asked Claude to check CloudWatch logs. Identified `ValueError: could not convert string to float` — the inference.py was corrupting raw bytes
+- Redeployed using our original `deploy.py` (native XGBoost, no inference.py) — endpoint restored
+- **Resolution:** Added churn endpoint to `sagemaker.tf` initially, then agreed with Troy to remove ALL SageMaker resources from Terraform. Endpoints now managed exclusively by `sagemaker-deploy.yml` GitHub Actions workflow. Single owner per resource prevents conflicts.
+
+### Systematic PR Review Process
+- Reviewed a large PR (132k additions) across k8s, Terraform, sentiment service, model artifacts
+- **My approach:** Organized review into categories: Blocking (will break), Merge Conflicts, Structural (won't break immediately but creates problems), and Positive (acknowledge good work)
+- Led with positives (guardrails, EKS, k8s services), then blocking items with specific file/line references
+- **Key findings:**
+  - Env var naming inconsistency across configmap, docker-compose, and code — three names for one value
+  - Cross-service imports that won't resolve in Docker containers
+  - API output format needed alignment with downstream consumers
+  - Directory restructuring would break existing docker-compose and CI/CD references
+- **My guidance:** Asked Claude to walk through each issue with multiple solution options, then compiled into a single structured review comment on the PR
+
+### Amazon Transcribe Pipeline (Stretch Goal)
+- Built as an independent workstream while the sentiment endpoint integration was in progress
+- **Lambda function:** S3 audio upload → Amazon Transcribe job with speaker diarization (2 speakers) → transcript saved to S3
+- **Deploy script:** Standalone `deploy_lambda.py` using boto3 (not Terraform) — cleaner for Lambda-specific logic
+- **API endpoints:** Added `/transcribe`, `/transcripts`, `/transcripts/{name}` to churn predictor API
+- **Frontend:** New Transcribe tab (third tab) — file upload, transcript list, speaker-segmented viewer
+- **Bug found:** Transcribe outputs speaker labels differently than expected. The `speaker_labels.segments.items` array only has timestamps — the actual text content is in the top-level `results.items` array with `speaker_label` on each item. Fixed the parser to read from the correct location.
+- **Speaker label logic:** Initially defaulted single-speaker transcripts to "Agent". I caught this — a single speaker saying "I'm experiencing an issue with your product" is clearly a customer. Changed to: two speakers = Agent/Customer, one speaker = "Speaker".
+
+### LangGraph Strategist Node
+- **Troy's concern:** Questioned whether our LangGraph flow was truly "agentic" vs just a pipeline
+- **My analysis:** The flow IS agentic — Claude selects tools based on the question, can skip tools, can chain multiple tools, can loop. But it's predictable in practice because inputs are structured.
+- **My question:** "Should we add another agent responsible for evaluating the churn risk and determining the best recommendation?"
+- **Outcome:** Added a Retention Strategist node to the graph — a second LLM call with a different system prompt focused on action selection. No new service needed, just a new node in the existing graph.
+- **Design decision:** Strategist uses base LLM without tools (reasoning only). Creates two distinct LLM calls visible in LangSmith: Gatherer (collects data) → Strategist (recommends action).
+- **Rubric alignment:** Re-read the assessment requirements. The rubric says "orchestration layer" and "chains or agents" — not "multiple agents." SageMaker endpoints are endpoints, not agents. The single LangGraph orchestrator with multi-step reasoning IS the agentic behavior the rubric asks for.
+
+### Version Conflicts — LangChain/LangGraph
+- Troy's CI/CD workflow was failing on `pip install` due to version conflicts
+- **Root cause:** `requirements.txt` had `langchain==0.3.0` but `langgraph>=0.2.0` — these version-lock `langchain-core` and conflicted
+- Updated to match our working local versions: `langchain>=1.2.0`, `langchain-aws>=1.2.0`, `langgraph>=1.0.0`, `langsmith>=0.6.0`
+
+---
+
+## Instances Where I Provided Guidance — Session 3
+
+### 22. Terraform vs deploy.py Ownership
+**Situation:** Troy removed all SageMaker resources from `sagemaker.tf`. I initially wanted Terraform to manage them for the rubric.
+**My realization:** The roadmap already documents `sagemaker-deploy.yml` as the endpoint manager. Having both caused the exact conflict that broke the endpoint. One owner per resource is correct.
+**Outcome:** Approved Troy's change.
+
+### 23. Systematic PR Review
+**My approach:** Instead of commenting on individual lines, organized the review into prioritized categories (Blocking → Conflicts → Structural → Positive). Asked Claude to compile multiple solution options for each issue.
+**Outcome:** Posted comprehensive review with actionable steps for each issue.
+
+### 24. Transcribe Speaker Labels
+**My observation:** Single-speaker transcript was labeled "Agent" — wrong assumption. A person saying "I have an issue with your product" is a customer.
+**Outcome:** Changed logic: two speakers = Agent/Customer (first speaker is agent), one speaker = neutral "Speaker" label.
+
+### 25. Questioning "Agentic" Architecture
+**My concern:** "I just don't think agents 1 and 2 are agents. They are just endpoints."
+**Outcome:** Re-read the rubric requirements carefully. Confirmed the rubric uses "agent" only for the orchestration layer, calls SageMaker components "endpoints." Correct framing matters for the presentation.
+
+### 26. Strategist vs New Service
+**My question:** Should the strategist be a separate service (true multi-agent) or a node in the existing graph?
+**Claude's recommendation:** Node in the existing graph — 30 minutes vs a full new service, less risk before demo.
+**My decision:** Agreed. One graph with two reasoning phases is architecturally cleaner and still shows multi-step reasoning in LangSmith.
+
+---
+
+### What I Would Do Differently
+- Start with the XGBoost container from the beginning instead of sklearn (would have saved 6 deploy attempts)
+- Upload Agent 1 synthetic data to S3 immediately instead of relying on local file paths
+- Set up docker-compose for local development earlier in the project
+- Establish stricter PR review process — too many files were modified outside lane ownership
+- Use LangGraph from the start instead of AgentExecutor — the explicit state graph is easier to reason about and debug
+- Set up LangSmith from Day 1 — would have caught the action selection issue much earlier
+- Establish single-owner-per-resource rule for infrastructure from Day 1 — would have prevented the Terraform/deploy.py endpoint conflict
+- Build the Transcribe pipeline earlier — it's independent of other work and adds AWS service breadth for the rubric

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,7 +8,7 @@ import {
 } from "lucide-react";
 
 const CHURN_API_URL = import.meta.env.VITE_CHURN_API_URL || "http://localhost:8001";
-const SENTIMENT_API_URL = import.meta.env.VITE_SENTIMENT_API_URL || "http://localhost:8000";
+const SENTIMENT_API_URL = import.meta.env.VITE_SENTIMENT_API_URL || "http://localhost:8002";
 const AGENT_API_URL = import.meta.env.VITE_AGENT_API_URL || "http://localhost:8000";
 
 // ── Types ────────────────────────────────────────────────────────────
@@ -260,10 +260,36 @@ function AnalyzeTab() {
     if (!customerId) { setError("Select a customer ID"); return; }
     setLoading(true); setError(null); setResult(null);
     try {
+      const predictPayload: Record<string, unknown> = { customer_id: customerId };
+
+      // If transcript provided, analyze it via sentiment API first
+      if (transcript.trim().length > 10) {
+        const sentRes = await fetch(`${SENTIMENT_API_URL}/predict`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ transcript: transcript.trim(), customer_id: customerId }),
+        });
+        if (sentRes.ok) {
+          const sentData = await sentRes.json();
+          predictPayload.qa_score = sentData.qa_score;
+          predictPayload.sentiment = sentData.sentiment;
+          predictPayload.emotion_frustration = sentData.emotion_frustration;
+          predictPayload.emotion_anger = sentData.emotion_anger;
+          predictPayload.sentiment_shift = sentData.sentiment_shift;
+          predictPayload.escalation_flag = sentData.escalation_flag ? 1 : 0;
+          predictPayload.resolution_flag = sentData.resolution_flag ? 1 : 0;
+        }
+
+        // Save transcript to S3 in the background
+        fetch(`${CHURN_API_URL}/save-transcript?customer_id=${encodeURIComponent(customerId)}&transcript=${encodeURIComponent(transcript.trim())}&source=analyze`, {
+          method: "POST",
+        }).catch(() => {});
+      }
+
       const res = await fetch(`${CHURN_API_URL}/predict`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ customer_id: customerId }),
+        body: JSON.stringify(predictPayload),
       });
       if (!res.ok) {
         const err = await res.json().catch(() => ({ detail: `HTTP ${res.status}` }));
@@ -512,6 +538,7 @@ interface TranscriptDetail {
 }
 
 function TranscribeTab() {
+  const [customerId, setCustomerId] = useState("");
   const [uploading, setUploading] = useState(false);
   const [uploadResult, setUploadResult] = useState<string | null>(null);
   const [transcripts, setTranscripts] = useState<TranscriptMeta[]>([]);
@@ -542,7 +569,10 @@ function TranscribeTab() {
     try {
       const formData = new FormData();
       formData.append("file", file);
-      const res = await fetch(`${CHURN_API_URL}/transcribe`, {
+      const url = customerId
+        ? `${CHURN_API_URL}/transcribe?customer_id=${encodeURIComponent(customerId)}`
+        : `${CHURN_API_URL}/transcribe`;
+      const res = await fetch(url, {
         method: "POST",
         body: formData,
       });
@@ -582,6 +612,10 @@ function TranscribeTab() {
           <div className="flex items-center gap-2 mb-4">
             <Mic className="w-4 h-4 text-gray-500" />
             <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide">Upload Audio</h2>
+          </div>
+          <div className="mb-4">
+            <CustomerCombobox value={customerId} onChange={setCustomerId} />
+            <p className="text-xs text-gray-400 mt-1">Associate this recording with a customer account</p>
           </div>
           <div
             className="border-2 border-dashed border-gray-300 rounded-lg p-8 text-center hover:border-trilink-light transition-colors cursor-pointer"

--- a/services/agent-service/chains/retention_agent.py
+++ b/services/agent-service/chains/retention_agent.py
@@ -30,7 +30,7 @@ You have four tools:
 
 ROUTING — choose the right approach based on the user's request:
 
-If asked about a specific customer (e.g., "tell me about C00036458"):
+If asked about a specific customer:
   1. Use get_customer_details to look up their account
   2. Use predict_churn to get their risk score
   3. Based on the risk level, recommend an approved action

--- a/services/agent-service/chains/retention_graph.py
+++ b/services/agent-service/chains/retention_graph.py
@@ -16,6 +16,7 @@ from tools.sentiment_tool import analyze_call
 from tools.churn_tool import predict_churn
 from tools.high_risk_tool import get_high_risk_customers
 from tools.customer_tool import get_customer_details
+from tools.transcript_tool import get_transcripts
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -31,9 +32,12 @@ When a user asks about a customer:
 2. ALWAYS call predict_churn to get their churn probability and risk level
 3. If a transcript is provided, call analyze_call for sentiment analysis
 4. If asked about high-risk customers, call get_high_risk_customers
+5. If asked about a customer's call history or transcripts, call get_transcripts
 
 You MUST call tools to gather data. Do not try to answer without data.
-After gathering data, summarize what you found factually — do not make recommendations yet."""
+After gathering data, provide ONLY a brief factual summary of the data you collected.
+DO NOT recommend actions, DO NOT suggest retention strategies, DO NOT provide analysis.
+Just state the facts — the Retention Strategist will handle recommendations."""
 
 STRATEGIST_PROMPT = """You are the Retention Strategist for TriLink Telecom.
 You receive customer data and churn analysis from the Data Gathering Agent.
@@ -73,9 +77,24 @@ class RetentionState(TypedDict):
 
 # ── LLM + Tools ──────────────────────────────────────────────────────
 
-tools = [get_customer_details, analyze_call, predict_churn, get_high_risk_customers]
+tools = [get_customer_details, analyze_call, predict_churn, get_high_risk_customers, get_transcripts]
+
+# Bedrock Guardrail — tuned for retention engine use case
+# Allows discussion of customer frustration/churn while blocking hate, PII, etc.
+# Uses retention-engine-guardrail (not sentiment-analysis-guardrail which was too strict)
+GUARDRAIL_ID = os.getenv("BEDROCK_GUARDRAIL_ID", "nvruz8wx5q83")
+GUARDRAIL_VERSION = os.getenv("BEDROCK_GUARDRAIL_VERSION", "DRAFT")
 
 llm = ChatBedrock(
+    model_id=MODEL_ID,
+    region_name=AWS_REGION,
+    model_kwargs={"max_tokens": 1024, "temperature": 0},
+    guardrails={"guardrailIdentifier": GUARDRAIL_ID, "guardrailVersion": GUARDRAIL_VERSION},
+)
+
+# Strategist LLM — no guardrail, since it produces retention recommendations
+# that contain terms (cancel, churn, frustrated) the guardrail would block
+llm_strategist = ChatBedrock(
     model_id=MODEL_ID,
     region_name=AWS_REGION,
     model_kwargs={"max_tokens": 1024, "temperature": 0},
@@ -117,7 +136,10 @@ def classify_request(state: RetentionState) -> RetentionState:
 def call_model(state: RetentionState) -> RetentionState:
     """Data Gathering Agent — calls tools to collect customer data."""
     system = SystemMessage(content=GATHERER_PROMPT)
-    response = llm_with_tools.invoke([system] + state["messages"])
+    response = llm_with_tools.invoke(
+        [system] + state["messages"],
+        config={"run_name": "DataGatherer"},
+    )
     return {"messages": [response], "request_type": state["request_type"],
             "customer_id": state.get("customer_id"), "has_transcript": state.get("has_transcript", False)}
 
@@ -125,16 +147,25 @@ def call_model(state: RetentionState) -> RetentionState:
 def handle_tool_response(state: RetentionState) -> RetentionState:
     """Data Gathering Agent — reviews tool results, may request more tools."""
     system = SystemMessage(content=GATHERER_PROMPT)
-    response = llm_with_tools.invoke([system] + state["messages"])
+    response = llm_with_tools.invoke(
+        [system] + state["messages"],
+        config={"run_name": "DataGatherer-ReviewTools"},
+    )
     return {"messages": [response], "request_type": state["request_type"],
             "customer_id": state.get("customer_id"), "has_transcript": state.get("has_transcript", False)}
 
 
 def strategist(state: RetentionState) -> RetentionState:
     """Retention Strategist — evaluates gathered data and recommends action."""
+    import logging
+    logger = logging.getLogger(__name__)
+    logger.info("[STRATEGIST] Node entered — generating recommendation")
     system = SystemMessage(content=STRATEGIST_PROMPT)
-    # Use base LLM without tools — strategist only reasons, doesn't call tools
-    response = llm.invoke([system] + state["messages"])
+    response = llm_strategist.invoke(
+        [system] + state["messages"],
+        config={"run_name": "RetentionStrategist"},
+    )
+    logger.info(f"[STRATEGIST] Response generated: {response.content[:100]}...")
     return {"messages": [response], "request_type": state["request_type"],
             "customer_id": state.get("customer_id"), "has_transcript": state.get("has_transcript", False)}
 
@@ -203,6 +234,7 @@ def build_retention_graph():
 # ── Singleton ─────────────────────────────────────────────────────────
 
 _graph = None
+_graph_version = 3  # bump this to force rebuild after code changes
 
 
 def get_graph():

--- a/services/agent-service/tools/churn_tool.py
+++ b/services/agent-service/tools/churn_tool.py
@@ -26,7 +26,7 @@ def predict_churn(
     The tool looks up account data internally by customer_id.
 
     Args:
-        customer_id: The customer ID (e.g., C00077940)
+        customer_id: The customer ID
         qa_score: Quality score from the call analysis, between 1 and 10
         sentiment: Sentiment from call analysis: Positive, Neutral, or Negative
         emotion_frustration: Frustration score from 0 to 1

--- a/services/agent-service/tools/customer_tool.py
+++ b/services/agent-service/tools/customer_tool.py
@@ -16,7 +16,7 @@ def get_customer_details(customer_id: str) -> str:
     Use this when asked about a specific customer's account or history.
 
     Args:
-        customer_id: The customer ID (e.g., C00036458)
+        customer_id: The customer ID
 
     Returns:
         JSON with account details, plan info, complaints, and call data

--- a/services/agent-service/tools/sentiment_tool.py
+++ b/services/agent-service/tools/sentiment_tool.py
@@ -1,36 +1,38 @@
 # services/agent-service/tools/sentiment_tool.py
-# LangChain Tool that calls Okino's Sentiment SageMaker endpoint
+# LangChain Tool that calls the Sentiment Analysis API
 
 import httpx
 import os
 from langchain.tools import tool
 
-SENTIMENT_URL = os.getenv(key="SENTIMENT_PREDICTOR_URL", default="http://localhost:8000")
+SENTIMENT_URL = os.getenv("SENTIMENT_URL", "http://localhost:8002")
+
 
 @tool
 def analyze_call(transcript: str) -> str:
     """
-    Analyzes a customer support call transcript for quality and sentiment.
+    Analyzes a customer support call transcript for sentiment, emotions, and quality.
     Use this tool when given a call transcript to evaluate.
-    Returns a sentiment classification along with other fields.
+    Returns qa_score, sentiment, emotion scores, escalation/resolution flags.
 
     Args:
         transcript: The full text of the customer support call
 
     Returns:
-        JSON string with qa_score and sentiment fields
+        JSON string with qa_score, sentiment, emotion_frustration, emotion_anger,
+        sentiment_shift, escalation_flag, resolution_flag
     """
     try:
         response = httpx.post(
-            url=f"{SENTIMENT_URL}/sentiment",
-            json={"text": transcript},
+            url=f"{SENTIMENT_URL}/predict",
+            json={"transcript": transcript},
             timeout=30.0,
         )
         response.raise_for_status()
-        return str(object=response.json())
+        return str(response.json())
     except httpx.TimeoutException:
-        return '{"error": "QA service timeout", "qa_score": 5, "sentiment": "unknown"}'
+        return '{"error": "Sentiment service timeout", "qa_score": 5, "sentiment": "unknown"}'
     except httpx.HTTPStatusError as e:
-        return f'{{"error": "QA service returned {e.response.status_code}", "qa_score": 5, "sentiment": "unknown"}}'
+        return f'{{"error": "Sentiment service returned {e.response.status_code}", "qa_score": 5, "sentiment": "unknown"}}'
     except Exception as e:
-        return f'{{"error": "{str(object=e)}", "qa_score": 5, "sentiment": "unknown"}}'
+        return f'{{"error": "{str(e)}", "qa_score": 5, "sentiment": "unknown"}}'

--- a/services/agent-service/tools/transcript_tool.py
+++ b/services/agent-service/tools/transcript_tool.py
@@ -1,0 +1,59 @@
+# services/agent-service/tools/transcript_tool.py
+# LangChain Tool that retrieves transcripts from S3 via the churn predictor API
+
+import httpx
+import os
+from langchain_core.tools import tool
+
+CHURN_URL = os.getenv("CHURN_PREDICTOR_URL", "http://localhost:8001")
+
+
+@tool
+def get_transcripts(customer_id: str) -> str:
+    """
+    Retrieves call transcripts for a specific customer.
+    Use this tool when asked about a customer's call history or transcripts.
+
+    Args:
+        customer_id: The customer ID
+
+    Returns:
+        JSON list of transcripts with text and speaker segments
+    """
+    try:
+        # List transcripts for this customer
+        response = httpx.get(
+            f"{CHURN_URL}/transcripts",
+            params={"customer_id": customer_id},
+            timeout=30.0,
+        )
+        response.raise_for_status()
+        transcript_list = response.json()
+
+        if not transcript_list:
+            return f'{{"message": "No transcripts found for customer {customer_id}"}}'
+
+        # Fetch the full text of each transcript
+        results = []
+        for t in transcript_list[:5]:  # limit to 5 most recent
+            detail_resp = httpx.get(
+                f"{CHURN_URL}/transcripts/{t['name']}",
+                timeout=30.0,
+            )
+            if detail_resp.status_code == 200:
+                detail = detail_resp.json()
+                results.append({
+                    "name": t["name"],
+                    "customer_id": t.get("customer_id"),
+                    "date": t.get("last_modified", ""),
+                    "transcript": detail.get("transcript", ""),
+                    "segments": detail.get("segments", []),
+                })
+
+        import json
+        return json.dumps(results, indent=2)
+
+    except httpx.HTTPStatusError as e:
+        return f'{{"error": "Transcript service returned {e.response.status_code}"}}'
+    except Exception as e:
+        return f'{{"error": "{str(e)}"}}'

--- a/services/churn-predictor-api/app.py
+++ b/services/churn-predictor-api/app.py
@@ -9,11 +9,12 @@ import io
 import json
 import os
 import logging
+import time
 
 import boto3
 import numpy as np
 import pandas as pd
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, UploadFile, File
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from typing import Any
@@ -381,3 +382,116 @@ def predict(req: PredictRequest) -> PredictResponse:
         raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(object=e))
+
+
+# --- Transcribe Pipeline Routes ---
+
+@app.post("/transcribe")
+async def upload_audio(file: UploadFile = File(...), customer_id: str | None = None):
+    """Upload an audio file to S3 audio/ prefix.
+    The Lambda trigger will automatically start a Transcribe job.
+    If customer_id is provided, the file is stored under audio/{customer_id}/."""
+    allowed_ext = {".wav", ".mp3", ".mp4", ".flac"}
+    ext = os.path.splitext(file.filename)[1].lower()
+    if ext not in allowed_ext:
+        raise HTTPException(status_code=400, detail=f"Unsupported format: {ext}. Use: {', '.join(allowed_ext)}")
+
+    if customer_id:
+        s3_key = f"audio/{customer_id}/{file.filename}"
+    else:
+        s3_key = f"audio/{file.filename}"
+    logger.info(f"Uploading audio: {s3_key}")
+
+    contents = await file.read()
+    s3.put_object(Bucket=S3_BUCKET, Key=s3_key, Body=contents)
+
+    return {
+        "status": "uploaded",
+        "s3_key": s3_key,
+        "filename": file.filename,
+        "customer_id": customer_id,
+        "message": "Transcription job will start automatically via Lambda trigger.",
+    }
+
+
+@app.get("/transcripts")
+def list_transcripts(customer_id: str | None = None):
+    """List completed transcripts. Optionally filter by customer_id."""
+    try:
+        prefix = f"transcripts/{customer_id}/" if customer_id else "transcripts/"
+        resp = s3.list_objects_v2(Bucket=S3_BUCKET, Prefix=prefix)
+        transcripts = []
+        for obj in resp.get("Contents", []):
+            key = obj["Key"]
+            if key.endswith(".json"):
+                name = os.path.basename(key).replace(".json", "")
+                parts = key.replace("transcripts/", "").split("/")
+                cid = parts[0] if len(parts) > 1 else None
+                transcripts.append({
+                    "name": name,
+                    "key": key,
+                    "size": obj["Size"],
+                    "last_modified": obj["LastModified"].isoformat(),
+                    "customer_id": cid,
+                })
+        transcripts.sort(key=lambda x: x["last_modified"], reverse=True)
+        return transcripts
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.get("/transcripts/{filename}")
+def get_transcript(filename: str):
+    """Retrieve a specific transcript and return the text + speaker segments."""
+    s3_key = f"transcripts/{filename}.json"
+    try:
+        obj = s3.get_object(Bucket=S3_BUCKET, Key=s3_key)
+        result = json.loads(obj["Body"].read().decode())
+
+        full_text = result["results"]["transcripts"][0]["transcript"]
+
+        segments = []
+        items = result["results"].get("items", [])
+        if items and items[0].get("speaker_label"):
+            current_speaker = None
+            current_words = []
+            for item in items:
+                speaker = item.get("speaker_label", current_speaker)
+                word = item["alternatives"][0]["content"] if item.get("alternatives") else ""
+                if speaker != current_speaker and current_words:
+                    segments.append({"speaker": current_speaker, "text": " ".join(current_words)})
+                    current_words = []
+                current_speaker = speaker
+                if word:
+                    if item.get("type") == "punctuation" and current_words:
+                        current_words[-1] += word
+                    else:
+                        current_words.append(word)
+            if current_words:
+                segments.append({"speaker": current_speaker, "text": " ".join(current_words)})
+
+        return {
+            "filename": filename,
+            "transcript": full_text,
+            "segments": segments,
+            "job_name": result.get("jobName", ""),
+        }
+    except s3.exceptions.NoSuchKey:
+        raise HTTPException(status_code=404, detail=f"Transcript '{filename}' not found")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.post("/save-transcript")
+def save_transcript(customer_id: str, transcript: str, source: str = "manual"):
+    """Save a text transcript to S3 for a customer."""
+    ts = int(time.time())
+    s3_key = f"transcripts/{customer_id}/{source}_{ts}.json"
+    payload = json.dumps({
+        "customer_id": customer_id,
+        "source": source,
+        "timestamp": ts,
+        "transcript": transcript,
+    })
+    s3.put_object(Bucket=S3_BUCKET, Key=s3_key, Body=payload)
+    return {"status": "saved", "key": s3_key, "customer_id": customer_id}


### PR DESCRIPTION
## Summary
- Restore `/transcribe`, `/transcripts`, `/save-transcript` routes deleted by PR #66 merge
- Add `customer_id` support to transcribe upload and transcript listing
- Add Retention Strategist node to LangGraph — two-phase reasoning (DataGatherer → RetentionStrategist) visible in LangSmith traces
- Wire Bedrock Guardrail (`retention-engine-guardrail`) on gatherer input; strategist uses clean LLM to avoid blocking retention terminology
- Add `get_transcripts` LangChain tool — agent can now look up customer call transcripts (5 tools total)
- Update `sentiment_tool.py` to point to enriched sentiment API (port 8002)
- Add CustomerCombobox to Transcribe tab for customer association
- Wire Analyze tab: transcript provided → sentiment API → churn prediction with enriched fields
- Remove hardcoded customer IDs from all tool docstrings and prompts
- Update LLM usage docs with Session 3 work (Apr 9-14)

## Test plan
- [x] Agent service starts with strategist node (verified graph nodes include strategist)
- [x] LangSmith traces show DataGatherer and RetentionStrategist as labeled runs
- [x] Guardrail allows retention content through
- [x] Transcribe tab shows customer dropdown
- [x] TypeScript compiles clean
- [ ] End-to-end: paste transcript in Analyze tab → sentiment → churn → results