### PR TITLE
Harden EKS deploy and teardown workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -142,6 +142,28 @@ jobs:
             fi
           done
 
+      - name: Preflight cluster capacity
+        run: |
+          READY_NODES=$(kubectl get nodes --no-headers 2>/dev/null | awk '$2 == "Ready" {count++} END {print count+0}')
+          NOT_READY_NODES=$(kubectl get nodes --no-headers 2>/dev/null | awk '$2 != "Ready" {count++} END {print count+0}')
+          PENDING_PODS=$(kubectl -n retention-engine get pods --no-headers 2>/dev/null | awk '$3 == "Pending" {count++} END {print count+0}')
+
+          echo "Ready nodes: $READY_NODES"
+          echo "NotReady nodes: $NOT_READY_NODES"
+          echo "Pending pods in retention-engine: $PENDING_PODS"
+
+          if [ "$READY_NODES" -lt 3 ]; then
+            echo "❌ Insufficient Ready nodes for safe rollout. Need at least 3 Ready nodes before restarting deployments."
+            kubectl get nodes
+            exit 1
+          fi
+
+          if [ "$PENDING_PODS" -gt 0 ]; then
+            echo "❌ Cluster already has Pending pods in retention-engine. Refusing to start rollout while capacity is constrained."
+            kubectl -n retention-engine get pods
+            exit 1
+          fi
+
       - name: Roll out deployments sequentially
         run: |
           for dep in agent-service churn-predictor sentiment-predictor frontend-deployment; do

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -142,15 +142,11 @@ jobs:
             fi
           done
 
-      - name: Restart deployments (pull latest image)
+      - name: Roll out deployments sequentially
         run: |
           for dep in agent-service churn-predictor sentiment-predictor frontend-deployment; do
+            echo "Restarting $dep..."
             kubectl rollout restart deployment/$dep -n retention-engine || true
-          done
-
-      - name: Wait for rollout
-        run: |
-          for dep in agent-service churn-predictor sentiment-predictor; do
             echo "Waiting for $dep..."
             kubectl rollout status deployment/$dep -n retention-engine --timeout=300s
           done

--- a/.github/workflows/sagemaker-deploy.yml
+++ b/.github/workflows/sagemaker-deploy.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Wait for Sentiment Endpoint
         if: inputs.action == 'deploy' && (inputs.endpoint == 'both' || inputs.endpoint == 'sentiment')
         run: |
-          ENDPOINT_NAME="retention-sentiment-analysis-endpoint"
+          ENDPOINT_NAME="retention-sentiment-revised-endpoint"
           for i in $(seq 1 30); do
             STATUS=$(aws sagemaker describe-endpoint \
               --endpoint-name "$ENDPOINT_NAME" \
@@ -133,9 +133,9 @@ jobs:
       - name: Validate Sentiment Inference
         if: inputs.action == 'deploy' && (inputs.endpoint == 'both' || inputs.endpoint == 'sentiment')
         run: |
-          echo -n '{"inputs": "The customer expressed frustration about repeated billing errors."}' > /tmp/sentiment-payload.json
+          echo -n '{"call_transcript": "The customer expressed frustration about repeated billing errors."}' > /tmp/sentiment-payload.json
           aws sagemaker-runtime invoke-endpoint \
-            --endpoint-name retention-sentiment-analysis-endpoint \
+            --endpoint-name retention-sentiment-revised-endpoint \
             --content-type application/json \
             --body fileb:///tmp/sentiment-payload.json \
             /tmp/sentiment-response.json

--- a/.github/workflows/teardown.yml
+++ b/.github/workflows/teardown.yml
@@ -135,17 +135,26 @@ jobs:
 
           kubectl delete namespace retention-engine --ignore-not-found
           kubectl wait --for=delete namespace/retention-engine --timeout=300s || {
+            if ! kubectl get namespace retention-engine >/dev/null 2>&1; then
+              echo "✅ Namespace no longer exists; treating teardown as successful"
+            else
             echo "Namespace deletion timed out; attempting finalizer removal"
             kubectl get namespace retention-engine -o yaml || true
             kubectl get all -n retention-engine || true
 
             kubectl patch namespace retention-engine --type=merge -p '{"spec":{"finalizers":[]}}' || true
             kubectl wait --for=delete namespace/retention-engine --timeout=120s || {
+              if ! kubectl get namespace retention-engine >/dev/null 2>&1; then
+                echo "✅ Namespace no longer exists after finalizer removal; treating teardown as successful"
+                exit 0
+              fi
+
               echo "Namespace still stuck after finalizer removal"
               kubectl get namespace retention-engine -o yaml || true
               kubectl get all -n retention-engine || true
               exit 1
             }
+            fi
           }
 
           kubectl delete ingressclass alb --ignore-not-found

--- a/.github/workflows/teardown.yml
+++ b/.github/workflows/teardown.yml
@@ -135,10 +135,17 @@ jobs:
 
           kubectl delete namespace retention-engine --ignore-not-found
           kubectl wait --for=delete namespace/retention-engine --timeout=300s || {
-            echo "Namespace deletion timed out; dumping remaining resources for debugging"
+            echo "Namespace deletion timed out; attempting finalizer removal"
             kubectl get namespace retention-engine -o yaml || true
             kubectl get all -n retention-engine || true
-            exit 1
+
+            kubectl patch namespace retention-engine --type=merge -p '{"spec":{"finalizers":[]}}' || true
+            kubectl wait --for=delete namespace/retention-engine --timeout=120s || {
+              echo "Namespace still stuck after finalizer removal"
+              kubectl get namespace retention-engine -o yaml || true
+              kubectl get all -n retention-engine || true
+              exit 1
+            }
           }
 
           kubectl delete ingressclass alb --ignore-not-found

--- a/.github/workflows/teardown.yml
+++ b/.github/workflows/teardown.yml
@@ -133,29 +133,49 @@ jobs:
             echo "$REMAINING_PODS" | xargs -r kubectl -n retention-engine delete --force --grace-period=0 --ignore-not-found
           fi
 
+          if ! kubectl get namespace retention-engine >/dev/null 2>&1; then
+            echo "✅ Namespace already absent; treating teardown as successful"
+            kubectl delete ingressclass alb --ignore-not-found
+            echo "✅ Kubernetes resources deleted"
+            exit 0
+          fi
+
           kubectl delete namespace retention-engine --ignore-not-found
-          kubectl wait --for=delete namespace/retention-engine --timeout=300s || {
+
+          for i in $(seq 1 30); do
             if ! kubectl get namespace retention-engine >/dev/null 2>&1; then
               echo "✅ Namespace no longer exists; treating teardown as successful"
-            else
-            echo "Namespace deletion timed out; attempting finalizer removal"
-            kubectl get namespace retention-engine -o yaml || true
-            kubectl get all -n retention-engine || true
-
-            kubectl patch namespace retention-engine --type=merge -p '{"spec":{"finalizers":[]}}' || true
-            kubectl wait --for=delete namespace/retention-engine --timeout=120s || {
-              if ! kubectl get namespace retention-engine >/dev/null 2>&1; then
-                echo "✅ Namespace no longer exists after finalizer removal; treating teardown as successful"
-                exit 0
-              fi
-
-              echo "Namespace still stuck after finalizer removal"
-              kubectl get namespace retention-engine -o yaml || true
-              kubectl get all -n retention-engine || true
-              exit 1
-            }
+              kubectl delete ingressclass alb --ignore-not-found
+              echo "✅ Kubernetes resources deleted"
+              exit 0
             fi
-          }
+
+            echo "[$i/30] Namespace still present — waiting 10s..."
+            sleep 10
+          done
+
+          echo "Namespace deletion timed out; attempting finalizer removal"
+          kubectl get namespace retention-engine -o yaml || true
+          kubectl get all -n retention-engine || true
+
+          kubectl patch namespace retention-engine --type=merge -p '{"spec":{"finalizers":[]}}' || true
+
+          for i in $(seq 1 12); do
+            if ! kubectl get namespace retention-engine >/dev/null 2>&1; then
+              echo "✅ Namespace no longer exists after finalizer removal; treating teardown as successful"
+              kubectl delete ingressclass alb --ignore-not-found
+              echo "✅ Kubernetes resources deleted"
+              exit 0
+            fi
+
+            echo "[$i/12] Namespace still present after finalizer removal — waiting 10s..."
+            sleep 10
+          done
+
+          echo "Namespace still stuck after finalizer removal"
+          kubectl get namespace retention-engine -o yaml || true
+          kubectl get all -n retention-engine || true
+          exit 1
 
           kubectl delete ingressclass alb --ignore-not-found
           echo "✅ Kubernetes resources deleted"

--- a/.github/workflows/teardown.yml
+++ b/.github/workflows/teardown.yml
@@ -125,7 +125,22 @@ jobs:
         if: inputs.scope == 'all' || inputs.scope == 'kubernetes'
         run: |
           echo "Deleting retention-engine namespace and all resources..."
-          kubectl delete namespace retention-engine --ignore-not-found --timeout=120s
+          kubectl delete all,configmap,secret,serviceaccount,ingress,pvc -n retention-engine --all --ignore-not-found || true
+
+          REMAINING_PODS=$(kubectl -n retention-engine get pods -o name 2>/dev/null || true)
+          if [ -n "$REMAINING_PODS" ]; then
+            echo "Force deleting stuck pods before namespace deletion..."
+            echo "$REMAINING_PODS" | xargs -r kubectl -n retention-engine delete --force --grace-period=0 --ignore-not-found
+          fi
+
+          kubectl delete namespace retention-engine --ignore-not-found
+          kubectl wait --for=delete namespace/retention-engine --timeout=300s || {
+            echo "Namespace deletion timed out; dumping remaining resources for debugging"
+            kubectl get namespace retention-engine -o yaml || true
+            kubectl get all -n retention-engine || true
+            exit 1
+          }
+
           kubectl delete ingressclass alb --ignore-not-found
           echo "✅ Kubernetes resources deleted"
 

--- a/k8s/deployments/agent-deployment.yaml
+++ b/k8s/deployments/agent-deployment.yaml
@@ -18,8 +18,8 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
+      maxSurge: 0
+      maxUnavailable: 1
   template:
     metadata:
       labels:

--- a/k8s/deployments/churn-predictor-deployment.yaml
+++ b/k8s/deployments/churn-predictor-deployment.yaml
@@ -17,8 +17,8 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
+      maxSurge: 0
+      maxUnavailable: 1
   template:
     metadata:
       labels:

--- a/k8s/deployments/frontend-deployment.yaml
+++ b/k8s/deployments/frontend-deployment.yaml
@@ -19,8 +19,8 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
+      maxSurge: 0
+      maxUnavailable: 1
   template:
     metadata:
       labels:

--- a/k8s/deployments/sentiment-predictor-deployment.yaml
+++ b/k8s/deployments/sentiment-predictor-deployment.yaml
@@ -16,8 +16,8 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
+      maxSurge: 0
+      maxUnavailable: 1
   template:
     metadata:
       labels:

--- a/k8s/namespace-quota.yaml
+++ b/k8s/namespace-quota.yaml
@@ -8,11 +8,11 @@ metadata:
   namespace: retention-engine
 spec:
   hard:
-    requests.cpu: "2"
-    requests.memory: "2Gi"
-    limits.cpu: "4"
-    limits.memory: "4Gi"
-    pods: "10"
+    requests.cpu: "3"
+    requests.memory: "3Gi"
+    limits.cpu: "6"
+    limits.memory: "6Gi"
+    pods: "15"
 ---
 apiVersion: v1
 kind: LimitRange

--- a/terraform/eks.tf
+++ b/terraform/eks.tf
@@ -28,12 +28,12 @@ resource "aws_eks_node_group" "retention_ng" {
   subnet_ids      = local.eks_subnet_ids
 
   scaling_config {
-    desired_size = 2
-    max_size     = 4
-    min_size     = 1
+    desired_size = 3
+    max_size     = 6
+    min_size     = 2
   }
 
-  instance_types = ["t3.medium"]
+  instance_types = ["t3.large"]
 
   depends_on = [
     aws_iam_role_policy_attachment.eks_node_AmazonEKSWorkerNodePolicy,


### PR DESCRIPTION
## Summary
This follow-up PR brings the post-merge fixes from `feat/sentiment-fallback-integration` back to `main`.

## What changed
- align SageMaker deploy validation with `retention-sentiment-revised-endpoint` and the enriched sentiment payload contract
- make EKS rollouts capacity-safe with sequential deployment handling and safer rolling update settings
- increase namespace quota and EKS node group capacity to reduce rollout exhaustion
- harden teardown so missing namespaces are treated as success and stuck namespace cleanup exits promptly

## Why
PR #75 merged before these workflow and infrastructure hardening changes were pushed. This PR carries the reliability fixes needed to keep deploy and teardown runs from failing on stale namespace state or insufficient EKS capacity.

## Notes
- Existing uncommitted local edits were not included in this PR.
- This PR targets `main` as a follow-up to the already-merged feature work in #75.
