### PR TITLE
Add ALB-ready deploy flow and public FastAPI docs URLs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -101,10 +101,18 @@ jobs:
       - name: Setup kubectl
         uses: azure/setup-kubectl@v3
 
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+
       - name: Write kubeconfig
         run: |
           mkdir -p $HOME/.kube
           echo "${{ secrets.KUBE_CONFIG }}" | base64 -d > $HOME/.kube/config
+
+      - name: Ensure ALB Controller Ready
+        run: |
+          export AWS_REGION="${{ vars.AWS_REGION }}"
+          bash ./scripts/ensure_alb_controller.sh
 
       - name: Apply K8s manifests
         run: |
@@ -173,50 +181,74 @@ jobs:
             kubectl rollout status deployment/$dep -n retention-engine --timeout=300s
           done
 
-      - name: Smoke test agent health
+      - name: Wait for public ALB
+        id: alb
         run: |
-          ALB_URL=$(kubectl get ingress retention-engine-ingress -n retention-engine \
-            -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' 2>/dev/null)
-          echo "ALB URL: $ALB_URL"
-          if [ -z "$ALB_URL" ]; then
-            echo "⚠️ No ALB hostname assigned yet — skipping smoke test"
-            echo "The ALB may take 2-3 minutes to provision"
-            kubectl get ingress -n retention-engine
-            exit 0
-          fi
-          # Wait for DNS to resolve (new ALBs can take 1-3 min)
-          echo "Waiting for ALB DNS to resolve..."
-          for i in $(seq 1 18); do
-            if nslookup "$ALB_URL" >/dev/null 2>&1; then
-              echo "DNS resolved after $((i * 10))s"
+          for i in $(seq 1 36); do
+            ALB_URL=$(kubectl get ingress retention-engine-ingress -n retention-engine \
+              -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' 2>/dev/null)
+            if [ -n "$ALB_URL" ]; then
+              echo "hostname=$ALB_URL" >> "$GITHUB_OUTPUT"
+              echo "ALB hostname assigned after $((i * 10))s: $ALB_URL"
               break
             fi
-            if [ "$i" -eq 18 ]; then
-              echo "⚠️ DNS not resolving after 3 min — skipping smoke test"
-              exit 0
-            fi
+            echo "[$i/36] Waiting for ALB hostname..."
             sleep 10
           done
-          curl -sf --retry 5 --retry-delay 10 --retry-all-errors "http://${ALB_URL}/health"
-          echo "✅ Agent service is healthy via ALB"
+
+          if [ -z "${ALB_URL:-}" ]; then
+            echo "❌ Timed out waiting for ALB hostname"
+            kubectl describe ingress retention-engine-ingress -n retention-engine
+            exit 1
+          fi
+
+          for i in $(seq 1 24); do
+            if nslookup "$ALB_URL" >/dev/null 2>&1; then
+              echo "DNS resolved after $((i * 10))s"
+              exit 0
+            fi
+            echo "[$i/24] Waiting for ALB DNS propagation..."
+            sleep 10
+          done
+
+          echo "❌ ALB hostname assigned but DNS did not resolve in time"
+          exit 1
+
+      - name: Smoke test public routes
+        run: |
+          BASE_URL="http://${{ steps.alb.outputs.hostname }}"
+          curl -sf --retry 5 --retry-delay 10 --retry-all-errors "$BASE_URL/health" >/dev/null
+          curl -sf --retry 5 --retry-delay 10 --retry-all-errors "$BASE_URL/agent-api/health" >/dev/null
+          curl -sf --retry 5 --retry-delay 10 --retry-all-errors "$BASE_URL/churn-api/health" >/dev/null
+          curl -sf --retry 5 --retry-delay 10 --retry-all-errors "$BASE_URL/sentiment-api/health" >/dev/null
+          curl -sf --retry 5 --retry-delay 10 --retry-all-errors "$BASE_URL/agent-api/docs" >/dev/null
+          curl -sf --retry 5 --retry-delay 10 --retry-all-errors "$BASE_URL/churn-api/docs" >/dev/null
+          curl -sf --retry 5 --retry-delay 10 --retry-all-errors "$BASE_URL/sentiment-api/docs" >/dev/null
+          echo "✅ Public frontend and FastAPI routes are reachable via ALB"
 
       - name: Deployment Summary
         run: |
-          ALB_URL=$(kubectl get ingress retention-engine-ingress -n retention-engine \
-            -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' 2>/dev/null)
+          ALB_URL="${{ steps.alb.outputs.hostname }}"
           echo "## Deployment Summary" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           if [ -n "$ALB_URL" ]; then
-            echo "### ALB Endpoint" >> "$GITHUB_STEP_SUMMARY"
+            echo "### Public Endpoints" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "| Route | URL |" >> "$GITHUB_STEP_SUMMARY"
             echo "|-------|-----|" >> "$GITHUB_STEP_SUMMARY"
             echo "| Frontend | http://${ALB_URL}/ |" >> "$GITHUB_STEP_SUMMARY"
-            echo "| Agent API | http://${ALB_URL}/agent-api/ |" >> "$GITHUB_STEP_SUMMARY"
-            echo "| Churn API | http://${ALB_URL}/churn-api/ |" >> "$GITHUB_STEP_SUMMARY"
-            echo "| Health | http://${ALB_URL}/health |" >> "$GITHUB_STEP_SUMMARY"
+            echo "| Frontend Health | http://${ALB_URL}/health |" >> "$GITHUB_STEP_SUMMARY"
+            echo "| Agent API Health | http://${ALB_URL}/agent-api/health |" >> "$GITHUB_STEP_SUMMARY"
+            echo "| Agent API Docs | http://${ALB_URL}/agent-api/docs |" >> "$GITHUB_STEP_SUMMARY"
+            echo "| Agent Chat | http://${ALB_URL}/agent-api/chat |" >> "$GITHUB_STEP_SUMMARY"
+            echo "| Churn API Health | http://${ALB_URL}/churn-api/health |" >> "$GITHUB_STEP_SUMMARY"
+            echo "| Churn API Docs | http://${ALB_URL}/churn-api/docs |" >> "$GITHUB_STEP_SUMMARY"
+            echo "| Churn High Risk | http://${ALB_URL}/churn-api/high-risk?limit=5 |" >> "$GITHUB_STEP_SUMMARY"
+            echo "| Sentiment API Health | http://${ALB_URL}/sentiment-api/health |" >> "$GITHUB_STEP_SUMMARY"
+            echo "| Sentiment API Docs | http://${ALB_URL}/sentiment-api/docs |" >> "$GITHUB_STEP_SUMMARY"
+            echo "| Sentiment Predict | http://${ALB_URL}/sentiment-api/predict |" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "⚠️ ALB not yet provisioned — check \`kubectl get ingress -n retention-engine\`" >> "$GITHUB_STEP_SUMMARY"
+            echo "❌ ALB not yet provisioned — check \`kubectl describe ingress -n retention-engine retention-engine-ingress\`" >> "$GITHUB_STEP_SUMMARY"
           fi
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "**Tag:** \`${{ inputs.tag }}\`  " >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sagemaker-deploy.yml
+++ b/.github/workflows/sagemaker-deploy.yml
@@ -49,6 +49,26 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ vars.AWS_REGION }}
 
+      - name: Setup kubectl
+        if: inputs.action == 'deploy'
+        uses: azure/setup-kubectl@v3
+
+      - name: Setup Helm
+        if: inputs.action == 'deploy'
+        uses: azure/setup-helm@v4
+
+      - name: Write kubeconfig
+        if: inputs.action == 'deploy'
+        run: |
+          mkdir -p "$HOME/.kube"
+          echo "${{ secrets.KUBE_CONFIG }}" | base64 -d > "$HOME/.kube/config"
+
+      - name: Ensure ALB Controller Ready
+        if: inputs.action == 'deploy'
+        run: |
+          export AWS_REGION="${{ vars.AWS_REGION }}"
+          bash ./scripts/ensure_alb_controller.sh
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -140,3 +160,14 @@ jobs:
             --body fileb:///tmp/sentiment-payload.json \
             /tmp/sentiment-response.json
           echo "✅ Sentiment endpoint response: $(cat /tmp/sentiment-response.json)"
+
+      - name: Endpoint Summary
+        if: always()
+        run: |
+          echo "## SageMaker Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Action: \`${{ inputs.action }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Endpoint selection: \`${{ inputs.endpoint }}\`" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ inputs.action }}" = "deploy" ] && kubectl get deployment aws-load-balancer-controller -n kube-system >/dev/null 2>&1; then
+            echo "- AWS Load Balancer Controller: ready in \`kube-system\`" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -89,29 +89,16 @@ jobs:
       - name: Install ALB Controller
         if: inputs.action == 'apply' && inputs.environment == 'dev'
         run: |
-          RAW_CLUSTER=$(kubectl config view --minify -o jsonpath='{.contexts[0].context.cluster}')
-          # Strip ARN prefix if present (arn:aws:eks:region:acct:cluster/name → name)
-          CLUSTER_NAME="${RAW_CLUSTER##*/}"
-          REGION="${{ vars.AWS_REGION }}"
-          ROLE_ARN=$(terraform output -raw alb_controller_role_arn)
-          echo "ALB Controller Role ARN: $ROLE_ARN"
+          export AWS_REGION="${{ vars.AWS_REGION }}"
+          export ALB_CONTROLLER_ROLE_ARN="$(terraform output -raw alb_controller_role_arn)"
+          bash ../scripts/ensure_alb_controller.sh
 
-          helm repo add eks https://aws.github.io/eks-charts
-          helm repo update
-
-          VPC_ID=$(aws eks describe-cluster --name "$CLUSTER_NAME" \
-            --query 'cluster.resourcesVpcConfig.vpcId' --output text)
-
-          helm upgrade --install aws-load-balancer-controller eks/aws-load-balancer-controller \
-            --namespace kube-system \
-            --set clusterName="$CLUSTER_NAME" \
-            --set region="$REGION" \
-            --set vpcId="$VPC_ID" \
-            --set serviceAccount.create=true \
-            --set serviceAccount.name=aws-load-balancer-controller \
-            --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"="$ROLE_ARN"
-
-          echo "Waiting for controller to be ready..."
-          kubectl rollout status deployment/aws-load-balancer-controller \
-            -n kube-system --timeout=120s
-          echo "✅ ALB Controller installed"
+      - name: Infrastructure Summary
+        if: inputs.action == 'apply'
+        run: |
+          echo "## Infrastructure Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Terraform apply completed for environment: \`${{ inputs.environment }}\`" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ inputs.environment }}" = "dev" ] && kubectl get deployment aws-load-balancer-controller -n kube-system >/dev/null 2>&1; then
+            echo "- AWS Load Balancer Controller: ready in \`kube-system\`" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -15,7 +15,7 @@ server {
 
     # Sentiment predictor service (sentiment)
     location /sentiment-api/ {
-        proxy_pass http://sentiment-predictor-service:8001/;
+        proxy_pass http://sentiment-predictor-service:8002/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/k8s/deployments/agent-deployment.yaml
+++ b/k8s/deployments/agent-deployment.yaml
@@ -30,6 +30,9 @@ spec:
           image: ghcr.io/lumin33r/agent-service:latest
           ports:
             - containerPort: 8080
+          env:
+            - name: FASTAPI_ROOT_PATH
+              value: /agent-api
           envFrom:
             - configMapRef:
                 name: agent-config

--- a/k8s/deployments/churn-predictor-deployment.yaml
+++ b/k8s/deployments/churn-predictor-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: churn-predictor
     team: retention-engine
-    
+
 spec:
   replicas: 1
   selector:
@@ -29,6 +29,9 @@ spec:
           image: ghcr.io/lumin33r/churn-predictor:latest
           ports:
             - containerPort: 8001
+          env:
+            - name: FASTAPI_ROOT_PATH
+              value: /churn-api
           envFrom:
             - secretRef:
                 name: aws-secrets

--- a/k8s/deployments/sentiment-predictor-deployment.yaml
+++ b/k8s/deployments/sentiment-predictor-deployment.yaml
@@ -28,6 +28,9 @@ spec:
           image: ghcr.io/lumin33r/sentiment-predictor:latest
           ports:
             - containerPort: 8002
+          env:
+            - name: FASTAPI_ROOT_PATH
+              value: /sentiment-api
           envFrom:
             - secretRef:
                 name: aws-secrets

--- a/scripts/ensure_alb_controller.sh
+++ b/scripts/ensure_alb_controller.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-}}"
+if [[ -z "$REGION" ]]; then
+  echo "AWS_REGION or AWS_DEFAULT_REGION must be set"
+  exit 1
+fi
+
+RAW_CLUSTER=$(kubectl config view --minify -o jsonpath='{.contexts[0].context.cluster}')
+CLUSTER_NAME="${EKS_CLUSTER_NAME:-${RAW_CLUSTER##*/}}"
+ROLE_NAME="${ALB_CONTROLLER_ROLE_NAME:-retention-engine-alb-controller-role}"
+ROLE_ARN="${ALB_CONTROLLER_ROLE_ARN:-}"
+
+if [[ -z "$ROLE_ARN" ]]; then
+  ROLE_ARN=$(aws iam get-role --role-name "$ROLE_NAME" --query 'Role.Arn' --output text)
+fi
+
+if [[ -z "$ROLE_ARN" || "$ROLE_ARN" == "None" ]]; then
+  echo "Unable to determine ALB controller IAM role ARN"
+  exit 1
+fi
+
+VPC_ID=$(aws eks describe-cluster --name "$CLUSTER_NAME" --query 'cluster.resourcesVpcConfig.vpcId' --output text)
+
+echo "Ensuring AWS Load Balancer Controller for cluster: $CLUSTER_NAME"
+echo "Using IAM role: $ROLE_ARN"
+
+if ! helm repo list | awk '{print $1}' | grep -qx eks; then
+  helm repo add eks https://aws.github.io/eks-charts
+fi
+helm repo update eks
+
+kubectl create serviceaccount aws-load-balancer-controller \
+  -n kube-system \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl annotate serviceaccount aws-load-balancer-controller \
+  -n kube-system \
+  eks.amazonaws.com/role-arn="$ROLE_ARN" \
+  --overwrite
+
+helm upgrade --install aws-load-balancer-controller eks/aws-load-balancer-controller \
+  --namespace kube-system \
+  --set clusterName="$CLUSTER_NAME" \
+  --set region="$REGION" \
+  --set vpcId="$VPC_ID" \
+  --set serviceAccount.create=false \
+  --set serviceAccount.name=aws-load-balancer-controller \
+  --wait
+
+kubectl rollout status deployment/aws-load-balancer-controller \
+  -n kube-system \
+  --timeout="${ALB_CONTROLLER_TIMEOUT:-180s}"
+
+echo "✅ AWS Load Balancer Controller is ready"

--- a/services/agent-service/app.py
+++ b/services/agent-service/app.py
@@ -2,6 +2,8 @@
 # FastAPI entry point for the LangChain agentic harness
 # Updated by Kathleen & Okino — passes customer_id to agent
 
+import os
+
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
@@ -10,7 +12,10 @@ import re
 
 load_dotenv()
 
-app = FastAPI(title="Retention Engine Agent Service")
+app = FastAPI(
+    title="Retention Engine Agent Service",
+    root_path=os.getenv("FASTAPI_ROOT_PATH", ""),
+)
 
 # --- Guardrails: approved retention actions by risk level ---
 APPROVED_ACTIONS = {

--- a/services/churn-predictor-api/app.py
+++ b/services/churn-predictor-api/app.py
@@ -22,7 +22,10 @@ from typing import Any
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(name=__name__)
 
-app = FastAPI(title="Churn Predictor API")
+app = FastAPI(
+    title="Churn Predictor API",
+    root_path=os.getenv("FASTAPI_ROOT_PATH", ""),
+)
 
 app.add_middleware(
     middleware_class=CORSMiddleware,

--- a/services/sentiment-analysis-api/app_enriched.py
+++ b/services/sentiment-analysis-api/app_enriched.py
@@ -27,7 +27,10 @@ load_dotenv()
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-app = FastAPI(title="Sentiment Analysis API")
+app = FastAPI(
+    title="Sentiment Analysis API",
+    root_path=os.getenv("FASTAPI_ROOT_PATH", ""),
+)
 
 app.add_middleware(
     CORSMiddleware,


### PR DESCRIPTION
## Summary
This follow-up PR adds ALB-controller readiness to the deployment workflows and publishes real public endpoint URLs in the deploy summary, including FastAPI docs URLs.

## What changed
- add a reusable script to install or repair the AWS Load Balancer Controller with the Terraform-managed IRSA role
- ensure the ALB controller is ready from `terraform.yml`, `sagemaker-deploy.yml`, and `deploy.yml`
- make `deploy.yml` wait for a real ALB hostname and DNS before smoke testing and writing summary links
- add public summary URLs for frontend, API health endpoints, and FastAPI docs
- fix the frontend reverse proxy for the sentiment service to use port `8002`
- configure FastAPI `root_path` values so `/agent-api/docs`, `/churn-api/docs`, and `/sentiment-api/docs` work correctly behind the ALB/frontend proxy

## Why
Recent deploys applied the ingress but did not have a running AWS Load Balancer Controller in the cluster, so no public ALB was ever provisioned. This change makes controller readiness part of the deployment path and ensures the workflow summary reports URLs that actually work.

## Notes
- The leftover local edits in `k8s/namespace-quota.yaml`, `terraform/eks.tf`, and the untracked `services/sentiment-analysis-api/app.py` were not included in this PR.
- This PR targets `main` as a follow-up to the already-merged workflow hardening work.
