### PR TITLE
Agent tool chaining + transcript lookup by customer_id

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -278,7 +278,10 @@ function AnalyzeTab() {
 
   async function loadSavedTranscript(name: string) {
     try {
-      const res = await fetch(`${CHURN_API_URL}/transcripts/${name}`);
+      const url = customerId
+        ? `${CHURN_API_URL}/transcripts/${name}?customer_id=${encodeURIComponent(customerId)}`
+        : `${CHURN_API_URL}/transcripts/${name}`;
+      const res = await fetch(url);
       if (res.ok) {
         const data = await res.json();
         setTranscript(data.transcript || "");
@@ -595,6 +598,7 @@ interface TranscriptMeta {
   key: string;
   size: number;
   last_modified: string;
+  customer_id: string | null;
 }
 
 interface TranscriptDetail {
@@ -658,10 +662,13 @@ function TranscribeTab() {
     if (fileInputRef.current) fileInputRef.current.value = "";
   }
 
-  async function viewTranscript(name: string) {
+  async function viewTranscript(name: string, cid?: string | null) {
     setLoadingTranscript(true); setSelectedTranscript(null);
     try {
-      const res = await fetch(`${CHURN_API_URL}/transcripts/${name}`);
+      const url = cid
+        ? `${CHURN_API_URL}/transcripts/${name}?customer_id=${encodeURIComponent(cid)}`
+        : `${CHURN_API_URL}/transcripts/${name}`;
+      const res = await fetch(url);
       if (res.ok) setSelectedTranscript(await res.json());
       else setError("Could not load transcript");
     } catch {
@@ -735,7 +742,7 @@ function TranscribeTab() {
               {transcripts.map((t) => (
                 <li
                   key={t.key}
-                  onClick={() => viewTranscript(t.name)}
+                  onClick={() => viewTranscript(t.name, t.customer_id)}
                   className={`p-3 rounded-lg border cursor-pointer transition-all hover:border-trilink-light ${
                     selectedTranscript?.filename === t.name
                       ? "border-trilink-light bg-trilink-light/5"

--- a/services/agent-service/chains/retention_graph.py
+++ b/services/agent-service/chains/retention_graph.py
@@ -29,10 +29,23 @@ Your job is to collect all relevant customer data by calling the appropriate too
 
 When a user asks about a customer:
 1. ALWAYS call get_customer_details to get their account information
-2. ALWAYS call predict_churn to get their churn probability and risk level
-3. If a transcript is provided, call analyze_call for sentiment analysis
+2. If a transcript is provided OR the customer has call_transcript data, FIRST call analyze_call
+   to get the enriched sentiment fields (qa_score, sentiment, emotion_frustration,
+   emotion_anger, sentiment_shift, escalation_flag, resolution_flag)
+3. ALWAYS call predict_churn. If you have enriched sentiment from step 2, PASS THOSE VALUES
+   into predict_churn as arguments. This ensures the churn prediction uses the current call's
+   sentiment, not stale synthetic defaults.
 4. If asked about high-risk customers, call get_high_risk_customers
 5. If asked about a customer's call history or transcripts, call get_transcripts
+
+CRITICAL: When you call analyze_call, save the returned values and pass them to predict_churn:
+  - qa_score from analyze_call → qa_score parameter of predict_churn
+  - sentiment from analyze_call → sentiment parameter of predict_churn
+  - emotion_frustration → emotion_frustration parameter
+  - emotion_anger → emotion_anger parameter
+  - sentiment_shift → sentiment_shift parameter
+  - escalation_flag (true/false) → escalation_flag parameter (1 or 0)
+  - resolution_flag (true/false) → resolution_flag parameter (1 or 0)
 
 You MUST call tools to gather data. Do not try to answer without data.
 After gathering data, provide ONLY a brief factual summary of the data you collected.

--- a/services/churn-predictor-api/app.py
+++ b/services/churn-predictor-api/app.py
@@ -444,17 +444,29 @@ def list_transcripts(customer_id: str | None = None):
 
 
 @app.get("/transcripts/{filename}")
-def get_transcript(filename: str):
-    """Retrieve a specific transcript and return the text + speaker segments."""
-    s3_key = f"transcripts/{filename}.json"
+def get_transcript(filename: str, customer_id: str | None = None):
+    """Retrieve a specific transcript and return the text + speaker segments.
+    If customer_id is provided, looks up transcripts/{customer_id}/{filename}.json.
+    Otherwise falls back to transcripts/{filename}.json (legacy path)."""
+    if customer_id:
+        s3_key = f"transcripts/{customer_id}/{filename}.json"
+    else:
+        s3_key = f"transcripts/{filename}.json"
     try:
         obj = s3.get_object(Bucket=S3_BUCKET, Key=s3_key)
         result = json.loads(obj["Body"].read().decode())
 
-        full_text = result["results"]["transcripts"][0]["transcript"]
+        # Handle two formats:
+        #   Transcribe output: {"results": {"transcripts": [...], "items": [...]}}
+        #   Manually saved:    {"transcript": "...", "customer_id": "...", ...}
+        if "results" in result:
+            full_text = result["results"]["transcripts"][0]["transcript"]
+            items = result["results"].get("items", [])
+        else:
+            full_text = result.get("transcript", "")
+            items = []
 
         segments = []
-        items = result["results"].get("items", [])
         if items and items[0].get("speaker_label"):
             current_speaker = None
             current_words = []


### PR DESCRIPTION
## Summary

Fixes two related issues discovered during demo prep:

### 1. Agent wasn't chaining sentiment → churn

On the Chat tab, when a user asked about a customer with a transcript, Claude was calling \`analyze_call\` and \`predict_churn\` separately — but not passing the enriched sentiment fields from \`analyze_call\` into \`predict_churn\`. The churn prediction was using stale synthetic Agent 1 data instead of the current call's sentiment.

**Fix:** Updated the Gatherer system prompt with:
- Explicit ordering: call \`analyze_call\` BEFORE \`predict_churn\` when transcript is available
- A CRITICAL block mapping each \`analyze_call\` output field → \`predict_churn\` parameter

### 2. Transcribe tab couldn't load transcripts under customer IDs

Clicking a transcript (e.g., \`sample_customer_call\` under customer \`C00036458\`) returned "Could not load transcript." The \`/transcripts/{filename}\` endpoint was looking in \`transcripts/\` root, but files live under \`transcripts/{customer_id}/\`.

**Fix:** 
- Churn API accepts optional \`customer_id\` query param; builds correct S3 path
- Frontend passes \`customer_id\` when loading transcripts on both Analyze and Transcribe tabs
- API now handles both Transcribe output format AND manually-saved transcript format

## Test plan

- [x] TypeScript compiles clean
- [x] \`/transcripts/{filename}?customer_id=X\` resolves to correct S3 key
- [ ] Transcribe tab: select customer → click saved transcript → text loads
- [ ] Analyze tab: select customer → click saved transcript → textarea populates
- [ ] Chat tab: "Analyze customer C00036458 with this transcript: ..." → LangSmith shows analyze_call params passed into predict_churn