### PR TITLE
Harden EKS deploy flow and swap sentiment endpoint integration

### DIFF
--- a/.github/workflows/ci-post-merge.yml
+++ b/.github/workflows/ci-post-merge.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Check sentiment endpoint
         run: |
           STATUS=$(aws sagemaker describe-endpoint \
-            --endpoint-name retention-sentiment-revised-endpoint \
+            --endpoint-name retention-sentiment-analysis-endpoint \
             --query 'EndpointStatus' --output text)
           echo "Sentiment endpoint: $STATUS"
           [ "$STATUS" = "InService" ] || exit 1
@@ -148,7 +148,7 @@ jobs:
         run: |
           PAYLOAD='{"call_transcript": "Customer is frustrated about repeated outages."}'
           aws sagemaker-runtime invoke-endpoint \
-            --endpoint-name retention-sentiment-revised-endpoint \
+            --endpoint-name retention-sentiment-analysis-endpoint \
             --content-type application/json \
             --body "$PAYLOAD" \
             /tmp/sentiment-out.json

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -120,7 +120,22 @@ jobs:
           kubectl apply -f k8s/namespace-quota.yaml
           kubectl apply -f k8s/configmaps/
           kubectl apply -f k8s/deployments/
-          kubectl apply -f k8s/services/
+
+          for attempt in 1 2 3; do
+            if kubectl apply -f k8s/services/; then
+              break
+            fi
+
+            if [ "$attempt" -eq 3 ]; then
+              echo "❌ Failed to apply services after 3 attempts"
+              exit 1
+            fi
+
+            echo "Service apply failed, re-checking ALB webhook readiness before retry $((attempt + 1))..."
+            export AWS_REGION="${{ vars.AWS_REGION }}"
+            bash ./scripts/ensure_alb_controller.sh
+          done
+
           kubectl apply -f k8s/ingress.yaml
 
       - name: Create secrets from GitHub secrets

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -136,7 +136,20 @@ jobs:
             bash ./scripts/ensure_alb_controller.sh
           done
 
-          kubectl apply -f k8s/ingress.yaml
+          for attempt in 1 2 3; do
+            if kubectl apply -f k8s/ingress.yaml; then
+              break
+            fi
+
+            if [ "$attempt" -eq 3 ]; then
+              echo "❌ Failed to apply ingress after 3 attempts"
+              exit 1
+            fi
+
+            echo "Ingress apply failed, re-checking ALB webhook readiness before retry $((attempt + 1))..."
+            export AWS_REGION="${{ vars.AWS_REGION }}"
+            bash ./scripts/ensure_alb_controller.sh
+          done
 
       - name: Create secrets from GitHub secrets
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,10 +40,41 @@ permissions:
 env:
   REGISTRY: ghcr.io
   IMAGE_PREFIX: ghcr.io/lumin33r
+  EKS_CLUSTER_NAME: eks-ezvrmopo-okl
+  EKS_DEPLOY_NODEGROUP: retention-ng
 
 jobs:
+  # ── Fail Fast On Cluster/Auth Drift ───────────────────────────────
+  preflight-cluster:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Setup kubectl
+        uses: azure/setup-kubectl@v3
+
+      - name: Write kubeconfig
+        run: |
+          mkdir -p $HOME/.kube
+          echo "${{ secrets.KUBE_CONFIG }}" | base64 -d > $HOME/.kube/config
+
+      - name: Validate node auth and target nodegroup capacity
+        run: |
+          bash ./scripts/check_eks_node_access.sh \
+            --cluster-name "$EKS_CLUSTER_NAME" \
+            --nodegroup "$EKS_DEPLOY_NODEGROUP" \
+            --min-ready 1
+
   # ── Build & Push Docker Images ────────────────────────────────────
   build-and-push:
+    needs: preflight-cluster
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -86,7 +117,7 @@ jobs:
 
   # ── Deploy to EKS ────────────────────────────────────────────────
   deploy-to-eks:
-    needs: build-and-push
+    needs: [preflight-cluster, build-and-push]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -177,6 +208,13 @@ jobs:
               echo "$PODS" | xargs kubectl delete pod -n retention-engine --ignore-not-found
             fi
           done
+
+      - name: Re-check node auth and target nodegroup capacity
+        run: |
+          bash ./scripts/check_eks_node_access.sh \
+            --cluster-name "$EKS_CLUSTER_NAME" \
+            --nodegroup "$EKS_DEPLOY_NODEGROUP" \
+            --min-ready 3
 
       - name: Preflight cluster capacity
         run: |

--- a/.github/workflows/sagemaker-deploy.yml
+++ b/.github/workflows/sagemaker-deploy.yml
@@ -1,9 +1,9 @@
 # .github/workflows/sagemaker-deploy.yml
-# Deploys and validates both SageMaker endpoints (churn XGBoost + sentiment DistilBERT)
+# Deploys the churn SageMaker endpoint and validates the external sentiment endpoint
 # Run AFTER terraform.yml has provisioned IAM roles and S3
 # See: CAPSTONE/docs/cicd-sagemaker-deploy.md
 
-name: 2 — SageMaker Endpoints
+name: 2 — SageMaker Validation
 
 on:
   push:
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
     inputs:
       endpoint:
-        description: "Which endpoint to deploy"
+        description: "Which endpoint to operate on"
         required: true
         type: choice
         options:
@@ -23,7 +23,7 @@ on:
           - sentiment
         default: both
       action:
-        description: "Deploy or delete"
+        description: "Deploy or delete managed endpoints"
         required: true
         type: choice
         options:
@@ -92,20 +92,11 @@ jobs:
           SAGEMAKER_ROLE_ARN: ${{ secrets.SAGEMAKER_ROLE_ARN }}
           S3_BUCKET: ${{ secrets.S3_BUCKET }}
 
-      # ── Deploy Sentiment Endpoint ───────────────────────────────────
-      - name: Deploy Sentiment Endpoint
+      - name: External sentiment endpoint notice
         if: inputs.endpoint == 'both' || inputs.endpoint == 'sentiment'
-        working-directory: sagemaker/sentiment
         run: |
-          if [ "${{ inputs.action }}" = "delete" ]; then
-            python deploy.py --delete
-          else
-            python deploy.py
-          fi
-        env:
-          AWS_REGION: ${{ vars.AWS_REGION }}
-          SAGEMAKER_ROLE_ARN: ${{ secrets.SAGEMAKER_ROLE_ARN }}
-          S3_BUCKET: ${{ secrets.S3_BUCKET }}
+          echo "ℹ️ Sentiment endpoint is externally managed and validate-only in this workflow."
+          echo "ℹ️ Target endpoint: retention-sentiment-analysis-endpoint"
 
       # ── Health Checks ───────────────────────────────────────────────
       - name: Wait for Churn Endpoint
@@ -126,7 +117,7 @@ jobs:
       - name: Wait for Sentiment Endpoint
         if: inputs.action == 'deploy' && (inputs.endpoint == 'both' || inputs.endpoint == 'sentiment')
         run: |
-          ENDPOINT_NAME="retention-sentiment-revised-endpoint"
+          ENDPOINT_NAME="retention-sentiment-analysis-endpoint"
           for i in $(seq 1 30); do
             STATUS=$(aws sagemaker describe-endpoint \
               --endpoint-name "$ENDPOINT_NAME" \
@@ -155,7 +146,7 @@ jobs:
         run: |
           echo -n '{"call_transcript": "The customer expressed frustration about repeated billing errors."}' > /tmp/sentiment-payload.json
           aws sagemaker-runtime invoke-endpoint \
-            --endpoint-name retention-sentiment-revised-endpoint \
+            --endpoint-name retention-sentiment-analysis-endpoint \
             --content-type application/json \
             --body fileb:///tmp/sentiment-payload.json \
             /tmp/sentiment-response.json
@@ -168,6 +159,8 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "- Action: \`${{ inputs.action }}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Endpoint selection: \`${{ inputs.endpoint }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Sentiment endpoint mode: externally managed, validate-only" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Sentiment endpoint target: \`retention-sentiment-analysis-endpoint\`" >> "$GITHUB_STEP_SUMMARY"
           if [ "${{ inputs.action }}" = "deploy" ] && kubectl get deployment aws-load-balancer-controller -n kube-system >/dev/null 2>&1; then
             echo "- AWS Load Balancer Controller: ready in \`kube-system\`" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/teardown.yml
+++ b/.github/workflows/teardown.yml
@@ -125,12 +125,12 @@ jobs:
         if: inputs.scope == 'all' || inputs.scope == 'kubernetes'
         run: |
           echo "Deleting retention-engine namespace and all resources..."
-          kubectl delete all,configmap,secret,serviceaccount,ingress,pvc -n retention-engine --all --ignore-not-found || true
+            kubectl delete all,configmap,secret,serviceaccount,ingress,pvc -n retention-engine --all --ignore-not-found --wait=false || true
 
           REMAINING_PODS=$(kubectl -n retention-engine get pods -o name 2>/dev/null || true)
           if [ -n "$REMAINING_PODS" ]; then
             echo "Force deleting stuck pods before namespace deletion..."
-            echo "$REMAINING_PODS" | xargs -r kubectl -n retention-engine delete --force --grace-period=0 --ignore-not-found
+              echo "$REMAINING_PODS" | xargs -r kubectl -n retention-engine delete --force --grace-period=0 --ignore-not-found --wait=false
           fi
 
           if ! kubectl get namespace retention-engine >/dev/null 2>&1; then
@@ -140,7 +140,7 @@ jobs:
             exit 0
           fi
 
-          kubectl delete namespace retention-engine --ignore-not-found
+          kubectl delete namespace retention-engine --ignore-not-found --wait=false
 
           for i in $(seq 1 30); do
             if ! kubectl get namespace retention-engine >/dev/null 2>&1; then

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,8 @@ services:
       dockerfile: Dockerfile
     ports:
       - "8002:8002"
+    environment:
+      - SENTIMENT_ENDPOINT_NAME=retention-sentiment-analysis-endpoint
     env_file:
       - .env
     healthcheck:

--- a/k8s/deployments/sentiment-predictor-deployment.yaml
+++ b/k8s/deployments/sentiment-predictor-deployment.yaml
@@ -31,6 +31,8 @@ spec:
           env:
             - name: FASTAPI_ROOT_PATH
               value: /sentiment-api
+            - name: SENTIMENT_ENDPOINT_NAME
+              value: retention-sentiment-analysis-endpoint
           envFrom:
             - secretRef:
                 name: aws-secrets

--- a/scripts/check_eks_node_access.sh
+++ b/scripts/check_eks_node_access.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/check_eks_node_access.sh [options]
+
+Validate that an EKS nodegroup's IAM role is authorized in aws-auth and that
+the cluster has enough Ready nodes in the target nodegroup for a safe rollout.
+
+Options:
+  --cluster-name NAME       EKS cluster name
+  --nodegroup NAME          EKS nodegroup name
+  --min-ready N             Minimum Ready nodes required in the target nodegroup (default: 1)
+  --help                    Show this help text
+EOF
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+CLUSTER_NAME=""
+NODEGROUP_NAME=""
+MIN_READY_NODES=1
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --cluster-name)
+      CLUSTER_NAME=${2:?Missing value for --cluster-name}
+      shift 2
+      ;;
+    --nodegroup)
+      NODEGROUP_NAME=${2:?Missing value for --nodegroup}
+      shift 2
+      ;;
+    --min-ready)
+      MIN_READY_NODES=${2:?Missing value for --min-ready}
+      shift 2
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+require_cmd aws
+require_cmd kubectl
+
+if [[ -z "$CLUSTER_NAME" || -z "$NODEGROUP_NAME" ]]; then
+  echo "Both --cluster-name and --nodegroup are required" >&2
+  exit 1
+fi
+
+NODE_ROLE_ARN=$(aws --no-cli-pager eks describe-nodegroup \
+  --cluster-name "$CLUSTER_NAME" \
+  --nodegroup-name "$NODEGROUP_NAME" \
+  --query 'nodegroup.nodeRole' \
+  --output text)
+
+if [[ -z "$NODE_ROLE_ARN" || "$NODE_ROLE_ARN" == "None" ]]; then
+  echo "Unable to determine node role for nodegroup $NODEGROUP_NAME" >&2
+  exit 1
+fi
+
+AWS_AUTH_ROLES=$(kubectl get configmap aws-auth -n kube-system -o jsonpath='{.data.mapRoles}')
+
+if ! grep -Fq "$NODE_ROLE_ARN" <<<"$AWS_AUTH_ROLES"; then
+  echo "❌ EKS node authorization drift detected" >&2
+  echo "Expected node role: $NODE_ROLE_ARN" >&2
+  kubectl get configmap aws-auth -n kube-system -o yaml >&2
+  exit 1
+fi
+
+READY_NODES=$(kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.labels.eks\.amazonaws\.com/nodegroup}{"|"}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' \
+  | awk -F'|' -v nodegroup="$NODEGROUP_NAME" '$1 == nodegroup && $2 == "True" {count++} END {print count+0}')
+
+TOTAL_NODES=$(kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.labels.eks\.amazonaws\.com/nodegroup}{"\n"}{end}' \
+  | awk -v nodegroup="$NODEGROUP_NAME" '$1 == nodegroup {count++} END {print count+0}')
+
+echo "Target nodegroup: $NODEGROUP_NAME"
+echo "Expected node role: $NODE_ROLE_ARN"
+echo "Registered nodes in nodegroup: $TOTAL_NODES"
+echo "Ready nodes in nodegroup: $READY_NODES"
+
+if [[ "$READY_NODES" -lt "$MIN_READY_NODES" ]]; then
+  echo "❌ Insufficient Ready nodes in nodegroup $NODEGROUP_NAME. Need at least $MIN_READY_NODES before rollout." >&2
+  kubectl get nodes -o wide >&2
+  exit 1
+fi
+
+echo "✅ EKS node authorization and nodegroup capacity look healthy"

--- a/scripts/ensure_alb_controller.sh
+++ b/scripts/ensure_alb_controller.sh
@@ -2,6 +2,50 @@
 
 set -euo pipefail
 
+wait_for_webhook() {
+  local attempts=${1:-24}
+  local sleep_seconds=${2:-5}
+  local secret_ca=""
+  local webhook_ca=""
+
+  echo "Waiting for ALB webhook TLS and admission readiness..."
+
+  for ((i=1; i<=attempts; i++)); do
+    secret_ca=$(kubectl get secret aws-load-balancer-tls -n kube-system -o jsonpath='{.data.ca\.crt}' 2>/dev/null || true)
+    webhook_ca=$(kubectl get mutatingwebhookconfiguration aws-load-balancer-webhook -o jsonpath='{.webhooks[2].clientConfig.caBundle}' 2>/dev/null || true)
+
+    if [[ -n "$secret_ca" && -n "$webhook_ca" && "$secret_ca" == "$webhook_ca" ]]; then
+      if cat <<'EOF' | kubectl apply --dry-run=server -f - >/dev/null 2>&1
+apiVersion: v1
+kind: Service
+metadata:
+  name: alb-webhook-probe
+  namespace: default
+spec:
+  selector:
+    app: does-not-matter
+  ports:
+    - port: 80
+      targetPort: 80
+  type: ClusterIP
+EOF
+      then
+        echo "✅ ALB webhook is ready"
+        return 0
+      fi
+    fi
+
+    echo "[$i/$attempts] Webhook not ready yet; waiting ${sleep_seconds}s..."
+    sleep "$sleep_seconds"
+  done
+
+  echo "ALB webhook did not become ready in time"
+  kubectl get secret aws-load-balancer-tls -n kube-system -o yaml || true
+  kubectl get mutatingwebhookconfiguration aws-load-balancer-webhook -o yaml || true
+  kubectl get deployment aws-load-balancer-controller -n kube-system -o yaml | sed -n '1,220p' || true
+  exit 1
+}
+
 REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-}}"
 if [[ -z "$REGION" ]]; then
   echo "AWS_REGION or AWS_DEFAULT_REGION must be set"
@@ -53,5 +97,7 @@ helm upgrade --install aws-load-balancer-controller eks/aws-load-balancer-contro
 kubectl rollout status deployment/aws-load-balancer-controller \
   -n kube-system \
   --timeout="${ALB_CONTROLLER_TIMEOUT:-180s}"
+
+wait_for_webhook
 
 echo "✅ AWS Load Balancer Controller is ready"

--- a/scripts/ensure_alb_controller.sh
+++ b/scripts/ensure_alb_controller.sh
@@ -6,15 +6,17 @@ wait_for_webhook() {
   local attempts=${1:-24}
   local sleep_seconds=${2:-5}
   local secret_ca=""
-  local webhook_ca=""
+  local mutating_webhook_ca=""
+  local validating_webhook_ca=""
 
   echo "Waiting for ALB webhook TLS and admission readiness..."
 
   for ((i=1; i<=attempts; i++)); do
     secret_ca=$(kubectl get secret aws-load-balancer-tls -n kube-system -o jsonpath='{.data.ca\.crt}' 2>/dev/null || true)
-    webhook_ca=$(kubectl get mutatingwebhookconfiguration aws-load-balancer-webhook -o jsonpath='{.webhooks[2].clientConfig.caBundle}' 2>/dev/null || true)
+    mutating_webhook_ca=$(kubectl get mutatingwebhookconfiguration aws-load-balancer-webhook -o jsonpath='{.webhooks[2].clientConfig.caBundle}' 2>/dev/null || true)
+    validating_webhook_ca=$(kubectl get validatingwebhookconfiguration aws-load-balancer-webhook -o jsonpath='{.webhooks[2].clientConfig.caBundle}' 2>/dev/null || true)
 
-    if [[ -n "$secret_ca" && -n "$webhook_ca" && "$secret_ca" == "$webhook_ca" ]]; then
+    if [[ -n "$secret_ca" && -n "$mutating_webhook_ca" && -n "$validating_webhook_ca" && "$secret_ca" == "$mutating_webhook_ca" && "$secret_ca" == "$validating_webhook_ca" ]]; then
       if cat <<'EOF' | kubectl apply --dry-run=server -f - >/dev/null 2>&1
 apiVersion: v1
 kind: Service
@@ -29,6 +31,7 @@ spec:
       targetPort: 80
   type: ClusterIP
 EOF
+      && kubectl apply --dry-run=server -f k8s/ingress.yaml >/dev/null 2>&1
       then
         echo "✅ ALB webhook is ready"
         return 0
@@ -42,6 +45,7 @@ EOF
   echo "ALB webhook did not become ready in time"
   kubectl get secret aws-load-balancer-tls -n kube-system -o yaml || true
   kubectl get mutatingwebhookconfiguration aws-load-balancer-webhook -o yaml || true
+  kubectl get validatingwebhookconfiguration aws-load-balancer-webhook -o yaml || true
   kubectl get deployment aws-load-balancer-controller -n kube-system -o yaml | sed -n '1,220p' || true
   exit 1
 }

--- a/scripts/ensure_alb_controller.sh
+++ b/scripts/ensure_alb_controller.sh
@@ -31,10 +31,11 @@ spec:
       targetPort: 80
   type: ClusterIP
 EOF
-      && kubectl apply --dry-run=server -f k8s/ingress.yaml >/dev/null 2>&1
       then
-        echo "✅ ALB webhook is ready"
-        return 0
+        if kubectl apply --dry-run=server -f k8s/ingress.yaml >/dev/null 2>&1; then
+          echo "✅ ALB webhook is ready"
+          return 0
+        fi
       fi
     fi
 

--- a/scripts/recycle_notready_nodes.sh
+++ b/scripts/recycle_notready_nodes.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/recycle_notready_nodes.sh [options]
+
+Safely replaces Kubernetes nodes that are NotReady by:
+  1. Attempting to cordon and drain the node
+  2. Deleting the stale Kubernetes Node object
+  3. Terminating the backing EC2 instance through its Auto Scaling Group
+     without decrementing desired capacity, so the nodegroup replaces it
+
+Options:
+  --cluster-name NAME       EKS cluster name for display only
+  --nodegroup NAME          Only target nodes in this EKS nodegroup label
+  --node NAME               Target a specific node; repeatable
+  --min-ready N             Refuse execution if fewer than N nodes are Ready (default: 2)
+  --wait-seconds N          Drain timeout in seconds (default: 60)
+  --execute                 Perform the replacement actions
+  --help                    Show this help text
+
+Examples:
+  ./scripts/recycle_notready_nodes.sh --nodegroup retention-ng
+  ./scripts/recycle_notready_nodes.sh --node ip-10-0-1-112.ec2.internal --execute
+  ./scripts/recycle_notready_nodes.sh --nodegroup retention-ng --execute
+EOF
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+get_ready_count() {
+  kubectl get nodes --no-headers 2>/dev/null | awk '$2 == "Ready" {count++} END {print count+0}'
+}
+
+jsonpath_field() {
+  local node_name=$1
+  local path=$2
+  kubectl get node "$node_name" -o "jsonpath=${path}" 2>/dev/null || true
+}
+
+drain_node() {
+  local node_name=$1
+  local timeout_seconds=$2
+
+  kubectl cordon "$node_name" >/dev/null 2>&1 || true
+  kubectl drain "$node_name" \
+    --ignore-daemonsets \
+    --delete-emptydir-data \
+    --force \
+    --grace-period=30 \
+    --timeout="${timeout_seconds}s" >/dev/null 2>&1 || true
+}
+
+CLUSTER_NAME="${EKS_CLUSTER_NAME:-}"
+NODEGROUP_FILTER=""
+MIN_READY_NODES=2
+DRAIN_TIMEOUT_SECONDS=60
+EXECUTE=false
+declare -a REQUESTED_NODES=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --cluster-name)
+      CLUSTER_NAME=${2:?Missing value for --cluster-name}
+      shift 2
+      ;;
+    --nodegroup)
+      NODEGROUP_FILTER=${2:?Missing value for --nodegroup}
+      shift 2
+      ;;
+    --node)
+      REQUESTED_NODES+=("${2:?Missing value for --node}")
+      shift 2
+      ;;
+    --min-ready)
+      MIN_READY_NODES=${2:?Missing value for --min-ready}
+      shift 2
+      ;;
+    --wait-seconds)
+      DRAIN_TIMEOUT_SECONDS=${2:?Missing value for --wait-seconds}
+      shift 2
+      ;;
+    --execute)
+      EXECUTE=true
+      shift
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+require_cmd kubectl
+require_cmd aws
+
+if [[ -z "$CLUSTER_NAME" ]]; then
+  raw_cluster=$(kubectl config view --minify -o jsonpath='{.contexts[0].context.cluster}' 2>/dev/null || true)
+  CLUSTER_NAME=${raw_cluster##*/}
+fi
+
+if [[ -z "$CLUSTER_NAME" ]]; then
+  echo "Unable to determine cluster name from kubeconfig; pass --cluster-name" >&2
+  exit 1
+fi
+
+READY_COUNT=$(get_ready_count)
+echo "Cluster: $CLUSTER_NAME"
+echo "Current Ready nodes: $READY_COUNT"
+echo "Execution mode: $([[ "$EXECUTE" == true ]] && echo EXECUTE || echo DRY-RUN)"
+
+if [[ "$EXECUTE" == true && "$READY_COUNT" -lt "$MIN_READY_NODES" ]]; then
+  echo "Refusing to proceed: only $READY_COUNT Ready nodes, below --min-ready=$MIN_READY_NODES" >&2
+  exit 1
+fi
+
+declare -a TARGET_NODES=()
+
+if [[ ${#REQUESTED_NODES[@]} -gt 0 ]]; then
+  TARGET_NODES=("${REQUESTED_NODES[@]}")
+else
+  while IFS='|' read -r node_name nodegroup ready_status; do
+    [[ -z "$node_name" ]] && continue
+    [[ "$ready_status" == "True" ]] && continue
+    if [[ -n "$NODEGROUP_FILTER" && "$nodegroup" != "$NODEGROUP_FILTER" ]]; then
+      continue
+    fi
+    TARGET_NODES+=("$node_name")
+  done < <(kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"|"}{.metadata.labels.eks\.amazonaws\.com/nodegroup}{"|"}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}')
+fi
+
+if [[ ${#TARGET_NODES[@]} -eq 0 ]]; then
+  echo "No matching NotReady nodes found"
+  exit 0
+fi
+
+echo "Target nodes:"
+printf '  - %s\n' "${TARGET_NODES[@]}"
+
+for node_name in "${TARGET_NODES[@]}"; do
+  nodegroup=$(jsonpath_field "$node_name" '{.metadata.labels.eks\.amazonaws\.com/nodegroup}')
+  provider_id=$(jsonpath_field "$node_name" '{.spec.providerID}')
+  ready_status=$(jsonpath_field "$node_name" '{.status.conditions[?(@.type=="Ready")].status}')
+  instance_id=${provider_id##*/}
+
+  if [[ -z "$provider_id" || "$instance_id" == "$provider_id" ]]; then
+    echo "Skipping $node_name: unable to determine provider ID" >&2
+    continue
+  fi
+
+  asg_name=$(aws --no-cli-pager autoscaling describe-auto-scaling-instances \
+    --instance-ids "$instance_id" \
+    --query 'AutoScalingInstances[0].AutoScalingGroupName' \
+    --output text 2>/dev/null || true)
+
+  if [[ -z "$asg_name" || "$asg_name" == "None" ]]; then
+    echo "Skipping $node_name: instance $instance_id is not attached to an Auto Scaling Group" >&2
+    continue
+  fi
+
+  echo
+  echo "Node: $node_name"
+  echo "  nodegroup: ${nodegroup:-unknown}"
+  echo "  ready: ${ready_status:-Unknown}"
+  echo "  instance: $instance_id"
+  echo "  asg: $asg_name"
+
+  echo "  workloads:"
+  kubectl get pods -A --field-selector "spec.nodeName=$node_name" -o wide 2>/dev/null || true
+
+  if [[ "$EXECUTE" != true ]]; then
+    echo "  dry-run actions: cordon/drain -> delete node -> terminate instance in ASG without decrementing desired capacity"
+    continue
+  fi
+
+  echo "  draining node..."
+  drain_node "$node_name" "$DRAIN_TIMEOUT_SECONDS"
+
+  echo "  deleting Kubernetes node object..."
+  kubectl delete node "$node_name" --ignore-not-found
+
+  echo "  terminating EC2 instance via ASG replacement..."
+  aws --no-cli-pager autoscaling terminate-instance-in-auto-scaling-group \
+    --instance-id "$instance_id" \
+    --no-should-decrement-desired-capacity >/dev/null
+
+  echo "  replacement requested for $instance_id"
+done
+
+if [[ "$EXECUTE" == true ]]; then
+  echo
+  echo "Replacement requests submitted. Monitor with:"
+  echo "  kubectl get nodes -o wide"
+  echo "  aws --no-cli-pager eks describe-nodegroup --cluster-name $CLUSTER_NAME --nodegroup-name ${NODEGROUP_FILTER:-<nodegroup>}"
+else
+  echo
+  echo "Dry run complete. Re-run with --execute to perform replacement."
+fi

--- a/services/sentiment-analysis-api/app_enriched.py
+++ b/services/sentiment-analysis-api/app_enriched.py
@@ -42,7 +42,7 @@ app.add_middleware(
 # --- Config ---
 AWS_REGION = os.getenv("AWS_REGION", "us-east-1")
 SENTIMENT_ENDPOINT = os.getenv(
-    "SENTIMENT_ENDPOINT_NAME", "retention-sentiment-revised-endpoint"
+    "SENTIMENT_ENDPOINT_NAME", "retention-sentiment-analysis-endpoint"
 )
 
 sagemaker_runtime = boto3.client("sagemaker-runtime", region_name=AWS_REGION)
@@ -242,7 +242,10 @@ def call_sagemaker_sentiment(transcript: str) -> dict:
         )
         result = json.loads(response["Body"].read().decode())
 
-        # Parse the nested response format
+        # Parse the nested response format.
+        # Prefer the explicit sentiment label when present because the
+        # externally managed endpoint does not share the revised endpoint's
+        # integer-to-label mapping.
         if isinstance(result, list) and len(result) > 0:
             inner = result[0]
             if isinstance(inner, str):
@@ -250,13 +253,24 @@ def call_sagemaker_sentiment(transcript: str) -> dict:
                 if isinstance(inner, list):
                     inner = inner[0]
 
+            sentiment_label = inner.get("sentiment_label")
             sentiment_int = inner.get("sentiment", 1)
             confidence = inner.get("confidence", 0.5)
         else:
+            sentiment_label = None
             sentiment_int = 1
             confidence = 0.5
 
-        label = SENTIMENT_LABELS.get(sentiment_int, "Neutral")
+        if isinstance(sentiment_label, str) and sentiment_label.strip():
+            normalized_label = sentiment_label.strip().lower()
+            label = {
+                "negative": "Negative",
+                "neutral": "Neutral",
+                "positive": "Positive",
+            }.get(normalized_label, sentiment_label.title())
+        else:
+            label = SENTIMENT_LABELS.get(sentiment_int, "Neutral")
+
         return {"sentiment": label, "confidence": confidence}
 
     except Exception as e:

--- a/terraform/kubernetes-auth.tf
+++ b/terraform/kubernetes-auth.tf
@@ -1,0 +1,34 @@
+data "aws_eks_cluster" "retention_eks" {
+  name = aws_eks_cluster.retention_eks.name
+}
+
+data "aws_eks_cluster_auth" "retention_eks" {
+  name = aws_eks_cluster.retention_eks.name
+}
+
+resource "kubernetes_config_map_v1_data" "aws_auth" {
+  metadata {
+    name      = "aws-auth"
+    namespace = "kube-system"
+  }
+
+  data = {
+    mapRoles = yamlencode([
+      {
+        rolearn  = aws_iam_role.eks_node_role.arn
+        username = "system:node:{{EC2PrivateDNSName}}"
+        groups = [
+          "system:bootstrappers",
+          "system:nodes",
+        ]
+      },
+    ])
+  }
+
+  force = true
+
+  depends_on = [
+    aws_eks_cluster.retention_eks,
+    aws_eks_node_group.retention_ng,
+  ]
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -8,9 +8,19 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 6.40.0"
     }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.32"
+    }
   }
 }
 
 provider "aws" {
   region = var.aws_region
+}
+
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.retention_eks.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.retention_eks.certificate_authority[0].data)
+  token                  = data.aws_eks_cluster_auth.retention_eks.token
 }


### PR DESCRIPTION
## Summary
This PR switches the sentiment integration to the externally managed legacy SageMaker endpoint and hardens the EKS deployment path after the cluster recovery work.

## What changed
- update the sentiment wrapper and deployment config to use `retention-sentiment-analysis-endpoint`
- make SageMaker validation workflow treat sentiment as externally managed
- harden ALB controller readiness checks and retry service/ingress apply during deploy
- make teardown stop waiting on stuck pods from dead nodes
- add a `recycle_notready_nodes.sh` recovery script for stale EKS workers
- manage EKS `aws-auth` declaratively in Terraform
- add an early deploy preflight that verifies node-role auth drift and target nodegroup readiness

## Why
The deploy pipeline was blocked by two separate infrastructure issues:
- ALB webhook readiness races during rollout
- stale `aws-auth` node role mapping that prevented replacement `retention-ng` workers from joining the cluster

These changes make the failure mode visible earlier, keep node auth in sync with Terraform, and preserve the recovery tooling used to restore the cluster.

## Validation
- deployed branch `sentiment-endpoint-swap`
- applied Terraform auth fix successfully
- verified replacement `retention-ng` nodes registered and converged to `Ready`
- reran workflow `3 — Build & Roll Out to EKS` successfully: run `24702006818`
