### PR TITLE
fix(strategist): enumerate list responses, constrain action codes to approved list

### DIFF
--- a/services/agent-service/chains/retention_graph.py
+++ b/services/agent-service/chains/retention_graph.py
@@ -66,6 +66,43 @@ APPROVED RETENTION ACTIONS:
   MEDIUM RISK (40-70%): FOLLOWUP_48H, GOODWILL_CREDIT, SPEED_BOOST
   LOW RISK (<40%): MONITOR
 
+CRITICAL CONSTRAINTS (apply to every response):
+
+1. Action codes are STRICT. The "Action:" field MUST contain exactly ONE code
+   from the APPROVED RETENTION ACTIONS list above. Do NOT invent new codes such
+   as "EXECUTIVE ESCALATION", "IMMEDIATE FIX", or "SUBSTANTIAL CREDIT". If the
+   situation feels more severe than any single approved code, pick the closest-
+   fit approved code (e.g., DEDICATED_SUPPORT for an executive-level intervention)
+   and explain the urgency in the Recommendation field, not in the Action code.
+
+2. The structured fields (Customer Summary, Churn Risk, Sentiment, Action,
+   Recommendation) MUST always appear in single-customer responses, even when
+   you also include a comparison table or before/after analysis. If you write a
+   comparison, place the structured fields at the END of the response so the
+   frontend can parse them.
+
+RESPONSE FORMAT — pick ONE based on the data you received:
+
+== LIST MODE — when the gathered data contains MULTIPLE customers ==
+(Typically from get_high_risk_customers or any "top N at-risk" query.)
+
+You MUST enumerate each customer individually. Do NOT collapse the list into a
+generic categorical summary. The manager needs to see WHO to focus on, not just
+that high-risk customers exist.
+
+For each customer in the list, output one block in this format:
+
+  - **{customer_id}** — {plan}, {contract_type}
+    Churn risk: {probability}% ({HIGH|MEDIUM|LOW})
+    Key drivers: {1-2 phrases citing sentiment, anger, qa_score, or escalation signals}
+    Recommended action: {ACTION_CODE from the approved list for that risk band}
+
+After the list, end with a single sentence noting any pattern across the cohort
+(e.g., "Three of the top five are on 24-month contracts with speed complaints —
+consider a coordinated TECH_VISIT campaign.").
+
+== SINGLE-CUSTOMER MODE — when the data is for one customer ==
+
 YOUR RESPONSE MUST INCLUDE:
 1. Customer summary (plan, tenure, key risk factors)
 2. Churn Risk: HIGH/MEDIUM/LOW with probability


### PR DESCRIPTION
## Summary

Two surgical Strategist prompt fixes uncovered during demo rehearsal. Both affect the same `STRATEGIST_PROMPT` in [services/agent-service/chains/retention_graph.py](services/agent-service/chains/retention_graph.py).

### 1. List-mode response branch

**Symptom:** A Chat query like "Who are my top 5 at-risk customers right now?" was returning a generic categorical summary ("these customers require urgent intervention with HIGH RISK actions: PLAN_UPGRADE, LOYALTY_DISCOUNT, ...") instead of naming any of the customers from the tool's response.

**Root cause:** The Strategist's prompt only had a single-customer template (numbered 1–5, all singular). With no list-mode branch, the model defaulted to abstracting the list away.

**Fix:** Added an explicit `LIST MODE` template that requires per-customer enumeration in this format:

> - **{customer_id}** — {plan}, {contract_type}
>   Churn risk: {probability}% ({HIGH|MEDIUM|LOW})
>   Key drivers: {phrases citing sentiment, anger, qa_score, escalation}
>   Recommended action: {APPROVED_CODE}

Closes with a single pattern sentence across the cohort.

### 2. CRITICAL CONSTRAINTS for action codes and structured fields

**Symptom A:** A "re-evaluate this customer with a new transcript" query returned a recommendation of "**EXECUTIVE ESCALATION + IMMEDIATE TECH FIX + SUBSTANTIAL CREDIT**" — none of which are in the approved HIGH list. The validate_action guardrail in [services/agent-service/app.py](services/agent-service/app.py) couldn't catch the drift because no parseable `Action:` line was emitted.

**Symptom B:** Same response abandoned the structured single-customer template (Customer Summary, Churn Risk, Sentiment, Action, Recommendation) in favor of a comparison table. The comparison content is useful, but the structured fields must remain present so the frontend's risk/sentiment/action cards can parse them.

**Fix:** Added a CRITICAL CONSTRAINTS block enforcing two rules:

1. The `Action:` field MUST contain exactly one code from the approved list. No invented codes. If the situation feels more severe than any single code, pick the closest fit (e.g., DEDICATED_SUPPORT for executive intervention) and explain the urgency in the Recommendation field.
2. Structured fields MUST always appear in single-customer responses, placed at the END of the response when a comparison or before/after analysis precedes them.

## Why now

The demo flow being rehearsed for the April 23 capstone presentation goes:

- Turn 1: top-5 leaderboard (now correctly enumerates customers)
- Turn 2: drill down on one customer
- Turn 3: paste a new transcript and re-evaluate (now keeps the comparison and the structured action)
- Turn 4: ask for the final recommendation from session memory

Without these fixes, Turns 1 and 3 don't substantiate the agentic-behavior claims made on the LangGraph slide.

## Test plan

- [ ] After deploy, send the Turn 1 prompt to `/agent-api/chat` and confirm the response enumerates customers individually with IDs and approved action codes
- [ ] Send the Turn 3 prompt with the angry transcript and confirm the response still ends with a parseable `Action: <APPROVED_CODE>` line
- [ ] Confirm the validate_action guardrail in app.py either accepts the chosen action or appends an override warning (no silent drift)
- [ ] Confirm the frontend Analyze tab's Action card still populates after this change (regression check, since the same Strategist serves both surfaces)