### PR TITLE
fix(agent): coordinate Gatherer and Strategist so the enumerated answer reaches the user

### DIFF
--- a/services/agent-service/chains/retention_graph.py
+++ b/services/agent-service/chains/retention_graph.py
@@ -48,9 +48,19 @@ CRITICAL: When you call analyze_call, save the returned values and pass them to 
   - resolution_flag (true/false) → resolution_flag parameter (1 or 0)
 
 You MUST call tools to gather data. Do not try to answer without data.
-After gathering data, provide ONLY a brief factual summary of the data you collected.
-DO NOT recommend actions, DO NOT suggest retention strategies, DO NOT provide analysis.
-Just state the facts — the Retention Strategist will handle recommendations."""
+
+When you have called all the tools you need and are ready to hand off to the
+Retention Strategist:
+- Output ONLY a single short acknowledgment line, such as "Customer data gathered."
+  or "High-risk list retrieved." or "Transcript analysis complete."
+- DO NOT enumerate, format, list, or tabulate the tool results
+- DO NOT produce tables, bullet lists, or structured customer summaries
+- DO NOT recommend actions or suggest retention strategies
+
+The Retention Strategist receives the tool results directly from the conversation
+history and is solely responsible for the final user-facing response. Anything
+you write that duplicates or pre-empts the Strategist's output will be discarded
+or shown out of order to the user."""
 
 STRATEGIST_PROMPT = """You are the Retention Strategist for TriLink Telecom.
 You receive customer data and churn analysis from the Data Gathering Agent.
@@ -65,6 +75,15 @@ APPROVED RETENTION ACTIONS:
   HIGH RISK (>70%): PLAN_UPGRADE, LOYALTY_DISCOUNT, SERVICE_CREDIT, TECH_VISIT, DEDICATED_SUPPORT, CONTRACT_FLEX
   MEDIUM RISK (40-70%): FOLLOWUP_48H, GOODWILL_CREDIT, SPEED_BOOST
   LOW RISK (<40%): MONITOR
+
+YOU OWN THE FINAL ANSWER:
+
+The Data Gatherer's message in the conversation history is intentionally a brief
+acknowledgment (e.g., "Customer data gathered."). The user has NOT seen any
+formatted analysis yet. The tool results are in the conversation history as
+ToolMessages — read them and produce the complete user-facing response yourself.
+Do NOT shortcut to a follow-up question like "Would you like me to..." assuming
+the answer is already on screen. It is not.
 
 CRITICAL CONSTRAINTS (apply to every response):
 


### PR DESCRIPTION
## Summary

Follow-up to PR #81. After the LIST MODE prompt landed, the Strategist began generating the correct enumerated table (verified in LangSmith), but the chat UI was still only displaying a follow-up question like *"Would you like me to generate specific retention recommendations for each of these customers?"* — the actual table was missing.

## Root cause

`invoke_graph` in [services/agent-service/chains/retention_graph.py](services/agent-service/chains/retention_graph.py) returns the LAST `AIMessage` with content from the graph state. Two AI messages were being produced per turn:

1. **Gatherer** (after reviewing tool results) — interpreted the prior instruction "provide ONLY a brief factual summary" generously and produced the entire formatted customer table itself.
2. **Strategist** — saw the table already in the message history, assumed the user had seen it, and shortcut to a CTA-only follow-up question.

The result: the substantive answer was the Gatherer's message, but `invoke_graph` returned the Strategist's CTA, hiding the Gatherer's table behind it.

## Fix

Two coordinated prompt edits to `STRATEGIST_PROMPT` and `GATHERER_PROMPT`:

**GATHERER_PROMPT — strict handoff:** when handing off to the Strategist, output exactly one short acknowledgment line such as `"Customer data gathered."` or `"High-risk list retrieved."`. Explicitly forbid tables, lists, structured customer summaries, or any pre-emption of the final answer. The tool results stay in `state["messages"]` as `ToolMessage`s for the Strategist to consume.

**STRATEGIST_PROMPT — `YOU OWN THE FINAL ANSWER` block:** explicitly tells the Strategist that the Gatherer's brief acknowledgment is *not* what the user has seen, and that it must read the tool results from message history and produce the complete formatted response itself. No CTA-only shortcuts.

## Why now

Demo rehearsal for the April 23 capstone presentation. Without this fix, the Chat tab's first turn ("Who are my top 5 at-risk customers?") shows only a follow-up CTA and not the customer enumeration the LangGraph slide claims the agent produces.

## Test plan

- [ ] After merge + deploy, send `Who are my top 5 at-risk customers right now?` to `/agent-api/chat` and confirm the chat UI shows the enumerated customer table from PR #81's LIST MODE template
- [ ] Confirm there is no leading or trailing CTA-only message that replaces the substantive answer
- [ ] Re-run Turns 2–4 of the demo flow (drill-down, paste-transcript re-eval, memory recall) and confirm Strategist output still includes the structured `Action:` and `Recommendation:` fields per PR #81's CRITICAL CONSTRAINTS
- [ ] LangSmith spot-check: in the run timeline, the Gatherer's final message should be a single short line (no table); the Strategist's message should contain the full enumerated answer