### PR TITLE
fix(agent): concat all substantive AI messages per turn so the answer can't be hidden behind a CTA

### DIFF
--- a/services/agent-service/chains/retention_graph.py
+++ b/services/agent-service/chains/retention_graph.py
@@ -327,9 +327,30 @@ def invoke_graph(user_message: str, customer_id: str | None = None, session_id: 
     config = {"configurable": {"thread_id": session_id}}
     result = graph.invoke(initial_state, config=config)
 
-    # Extract the last AI message
-    for msg in reversed(result["messages"]):
-        if isinstance(msg, AIMessage) and msg.content:
-            return msg.content
+    # MemorySaver keeps the entire session in result["messages"], so isolate
+    # this turn by slicing from the most recent HumanMessage forward.
+    last_human_idx = 0
+    for i, msg in enumerate(result["messages"]):
+        if isinstance(msg, HumanMessage):
+            last_human_idx = i
+
+    # Concatenate every substantive AI message from this turn.
+    # The graph can produce multiple AIMessages per turn (Gatherer review +
+    # Strategist), and either one may carry the substantive answer depending
+    # on how Claude interprets the prompts. Returning only the last one drops
+    # the table when the Strategist shortcuts to a CTA-only follow-up.
+    chunks: list[str] = []
+    for msg in result["messages"][last_human_idx + 1:]:
+        if not isinstance(msg, AIMessage):
+            continue
+        if not msg.content:
+            continue
+        # Skip messages whose only purpose is to invoke a tool
+        if getattr(msg, "tool_calls", None):
+            continue
+        chunks.append(msg.content)
+
+    if chunks:
+        return "\n\n".join(chunks)
 
     return "I wasn't able to process that request. Please try again."


### PR DESCRIPTION
## Summary

Runtime backstop for the prompt-coordination fix in PR #82. Demo rehearsal confirmed that even with the tightened Gatherer/Strategist prompts, Claude still occasionally produces a Gatherer message containing the substantive table and a Strategist message containing only a CTA-style follow-up question. The previous `invoke_graph` returned only the LAST AIMessage with content, so the table was silently dropped from the chat UI while remaining visible in LangSmith.

## What changed

[services/agent-service/chains/retention_graph.py](services/agent-service/chains/retention_graph.py) — `invoke_graph()`:

- Slice `result[\"messages\"]` to the current turn by finding the most recent `HumanMessage` (necessary because `MemorySaver` keeps the entire session history).
- Collect every `AIMessage` with non-empty content that is NOT a tool-call-only message.
- Join them with double-newline separators and return.

## Behavior matrix

| Scenario | Before | After |
|---|---|---|
| Strategist produces the full answer (intended path) | Returns Strategist content | Returns Strategist content (unchanged) |
| Gatherer produces the table, Strategist appends a CTA | Returns CTA only (answer hidden) | Returns table + CTA (correct) |
| Gatherer obeys brief-handoff, Strategist produces full answer | Returns Strategist content | Returns brief Gatherer ack + Strategist content (slightly noisier but correct) |
| Tool-call-only intermediate message | Skipped (no content) | Skipped (explicit `tool_calls` filter) |

## Why now

Demo for the April 23 capstone presentation. Turn 1 of the rehearsed Chat flow ("Who are my top 5 at-risk customers?") was returning a CTA-only message, breaking the LangGraph slide's claim that the agent enumerates customers from `get_high_risk_customers`.

## Test plan

- [ ] After merge + deploy, send `Who are my top 5 at-risk customers right now?` to `/agent-api/chat` and confirm the chat UI shows the enumerated customer list (with or without a trailing CTA — both are acceptable; the answer is visible either way).
- [ ] Re-run all four turns of the demo flow and confirm no turn returns a CTA-only response.
- [ ] LangSmith spot-check: confirm the run timeline still shows Gatherer and Strategist nodes; the chat response should now match what's visible in the trace, not a subset of it.
- [ ] Regression check: hit the Analyze tab. The frontend's risk/sentiment/action cards parse fields out of the response — confirm those still populate correctly under the new concat behavior (the Strategist's structured fields will be at the end of the concatenated output, which the regex still finds).