### PR TITLE
fix(ci): default deploy.yml inputs so push-triggered deploys actually rebuild

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,7 +93,12 @@ jobs:
       - name: Skip if not selected
         id: check
         run: |
-          if [[ "${{ inputs.service }}" != "all" && "${{ inputs.service }}" != "${{ matrix.name }}" ]]; then
+          # On push events, inputs.service is empty (only workflow_dispatch
+          # populates inputs). Default empty to "all" so auto-deploys from
+          # main rebuild every service rather than skipping the build step.
+          SVC="${{ inputs.service }}"
+          SVC="${SVC:-all}"
+          if [[ "$SVC" != "all" && "$SVC" != "${{ matrix.name }}" ]]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
@@ -113,7 +118,9 @@ jobs:
         with:
           context: ${{ matrix.context }}
           push: true
-          tags: ${{ env.IMAGE_PREFIX }}/${{ matrix.name }}:${{ inputs.tag }}
+          # Same input-default issue as `service` above — inputs.tag is empty
+          # on push events and would produce a malformed `:` suffix.
+          tags: ${{ env.IMAGE_PREFIX }}/${{ matrix.name }}:${{ inputs.tag || 'latest' }}
 
   # ── Deploy to EKS ────────────────────────────────────────────────
   deploy-to-eks:


### PR DESCRIPTION
## Summary

The deploy.yml workflow has been silently no-op for every auto-deploy from main since the matrix-based service selector was introduced. \`kubectl rollout restart\` ran on every merge, but the pod was always pulling the same stale \`:latest\` image because the build/push step itself was being skipped.

## Root cause

\`workflow_dispatch.inputs\` are only populated when the workflow is triggered manually. On a \`push\` event, every \`inputs.*\` reference resolves to empty string regardless of any \`default:\` declared in the inputs schema.

In the build-and-push job:

\`\`\`yaml
- name: Skip if not selected
  id: check
  run: |
    if [[ "${{ inputs.service }}" != "all" && "${{ inputs.service }}" != "${{ matrix.name }}" ]]; then
      echo "skip=true" >> "\$GITHUB_OUTPUT"
    ...
\`\`\`

On a push event, \`inputs.service\` is \`""\` — the check evaluates \`"" != "all"\` AND \`"" != "agent-service"\` (and the same for the other matrix entries), both true, so \`skip=true\`. The Login-to-GHCR and Build-and-push steps both gate on \`skip == 'false'\` and never run.

\`inputs.tag\` has the same issue — even if the build had run, the tag would be \`ghcr.io/lumin33r/agent-service:\` (malformed).

## Why this is being filed urgently

Demo rehearsal for the April 23 capstone presentation. Three consecutive prompt-engineering PRs (#82, #83, #84) all merged with green CI but had zero observable effect on the agent service in production — because the agent-service container image was never rebuilt. Confirmed by manually dispatching the workflow with \`service=all,tag=latest\`: all four build jobs completed successfully where the prior auto-deploy had skipped all four.

## Fix

Two small changes in [.github/workflows/deploy.yml](.github/workflows/deploy.yml):

1. Skip-check now defaults \`inputs.service\` to \`all\` when empty:
   \`\`\`bash
   SVC="${{ inputs.service }}"
   SVC="\${SVC:-all}"
   \`\`\`
2. Build/push tag now defaults \`inputs.tag\` to \`latest\` when empty:
   \`\`\`yaml
   tags: \${{ env.IMAGE_PREFIX }}/\${{ matrix.name }}:\${{ inputs.tag || 'latest' }}
   \`\`\`

After this lands, push events to main will rebuild every service in the matrix and tag it \`:latest\`, restoring the intended auto-deploy behavior. Manual dispatches with explicit service/tag continue to work as before.

## Test plan

- [ ] Merge this PR and observe the resulting auto-deploy run
- [ ] Confirm all four \`build-and-push (...)\` matrix jobs run their Build-and-push step (not skipped)
- [ ] Confirm the agent-service pod rolls and serves new code (curl /agent-api/chat and verify the response no longer has the leading \`\\n\\n\` artifact from PR #84's \_extract\_text fix that was never deployed)